### PR TITLE
Improve error messages

### DIFF
--- a/src/main/java/org/spdx/jacksonstore/JacksonDeSerializer.java
+++ b/src/main/java/org/spdx/jacksonstore/JacksonDeSerializer.java
@@ -171,7 +171,12 @@ public class JacksonDeSerializer {
 			throw new InvalidSPDXAnalysisException("Duplicate SPDX ID: "+id);
 		}
 		store.create(documentUri, id, type);
+		try {
 		restoreObjectPropertyValues(documentUri, id, jsonNode, spdxIdProperties);
+		} catch(InvalidSPDXAnalysisException ex) {
+			// Add more information to the error message
+			throw new InvalidSPDXAnalysisException("Error parsing JSON field for ID "+id+": "+ex.getMessage(), ex);
+		}
 		addedElements.put(id, new TypedValue(id, type));
 	}
 


### PR DESCRIPTION
Adds the SPDX ID to errors when there is an SPDX parsing exception.

Related to issue https://github.com/spdx/tools-java/issues/3

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>