### PR TITLE
Resolves issue18 using short form of listed reference types

### DIFF
--- a/src/main/java/org/spdx/jacksonstore/JacksonSerializer.java
+++ b/src/main/java/org/spdx/jacksonstore/JacksonSerializer.java
@@ -423,6 +423,8 @@ public class JacksonSerializer {
 			return SpdxConstants.NONE_VALUE;
 		} else if (SpdxConstants.URI_VALUE_NOASSERTION.equals(uri)) {
 			return SpdxConstants.NOASSERTION_VALUE;
+		} else if (uri.startsWith(SpdxConstants.SPDX_LISTED_REFERENCE_TYPES_PREFIX)) {
+		    return uri.substring(SpdxConstants.SPDX_LISTED_REFERENCE_TYPES_PREFIX.length());
 		} else {
 			return uri;
 		}


### PR DESCRIPTION
Also resolves an issue where the property documentDescribes is incorrectly added when deserializing (it should only be converted to a relationship).
Signed-off-by: Gary O'Neall <gary@sourceauditor.com>