### PR TITLE
Update JSON LD context

### DIFF
--- a/resources/spdx-2-2-revision-16-onotology.context.json
+++ b/resources/spdx-2-2-revision-16-onotology.context.json
@@ -16,6 +16,39 @@
       "@id" : "spdx:externalDocumentId",
       "@type" : "xs:anyURI"
     },
+    "homepage" : {
+      "@id" : "doap:homepage",
+      "@type" : "xs:anyURI"
+    },
+    "endPointer" : {
+      "@id" : "rdfpointer:endPointer",
+      "@type" : "rdfpointer:SinglePointer"
+    },
+    "lineNumber" : {
+      "@id" : "rdfpointer:lineNumber",
+      "@type" : "xs:positiveInteger"
+    },
+    "offset" : {
+      "@id" : "rdfpointer:offset",
+      "@type" : "xs:positiveInteger"
+    },
+    "reference" : {
+      "@id" : "rdfpointer:reference",
+      "@type" : "spdx:File"
+    },
+    "startPointer" : {
+      "@id" : "rdfpointer:startPointer",
+      "@type" : "rdfpointer:SinglePointer"
+    },
+    "comment" : {
+      "@id" : "rdfs:comment",
+      "@type" : "xs:string"
+    },
+    "seeAlsos" : {
+      "@id" : "rdfs:seeAlsos",
+      "@type" : "xs:string",
+      "@container" : "@set"
+    },
     "algorithm" : {
       "@id" : "spdx:algorithm",
       "@type" : "spdx:ChecksumAlgorithm"
@@ -59,10 +92,6 @@
     "checksumValue" : {
       "@id" : "spdx:checksumValue",
       "@type" : "xs:hexBinary"
-    },
-    "comment" : {
-      "@id" : "rdfs:comment",
-      "@type" : "xs:string"
     },
     "contextualExample" : {
       "@id" : "spdx:contextualExample",
@@ -114,10 +143,6 @@
     "downloadLocation" : {
       "@id" : "spdx:downloadLocation",
       "@type" : "xs:anyURI"
-    },
-    "endPointer" : {
-      "@id" : "rdfpointer:endPointer",
-      "@type" : "rdfpointer:SinglePointer"
     },
     "example" : {
       "@id" : "spdx:example",
@@ -177,10 +202,6 @@
       "@id" : "spdx:hasFiles",
       "@type" : "spdx:File",
       "@container" : "@set"
-    },
-    "homepage" : {
-      "@id" : "doap:homepage",
-      "@type" : "xs:anyURI"
     },
     "isDeprecatedLicenseId" : {
       "@id" : "spdx:isDeprecatedLicenseId",
@@ -265,13 +286,18 @@
       "@id" : "spdx:licenseTextHtml",
       "@type" : "xs:string"
     },
-    "lineNumber" : {
-      "@id" : "rdfpointer:lineNumber",
-      "@type" : "xs:positiveInteger"
-    },
     "match" : {
       "@id" : "spdx:match",
       "@type" : "xs:string"
+    },
+    "members" : {
+      "@id" : "spdx:members",
+      "@type" : "spdx:AnyLicenseInfo",
+      "@container" : "@set"
+    },
+    "member" : {
+      "@id" : "spdx:member",
+      "@type" : "spdx:AnyLicenseInfo"
     },
     "name" : {
       "@id" : "spdx:name",
@@ -280,10 +306,6 @@
     "noticeText" : {
       "@id" : "spdx:noticeText",
       "@type" : "xs:string"
-    },
-    "offset" : {
-      "@id" : "rdfpointer:offset",
-      "@type" : "xs:positiveInteger"
     },
     "order" : {
       "@id" : "spdx:order",
@@ -314,10 +336,6 @@
       "@id" : "spdx:ranges",
       "@type" : "rdfpointer:StartEndPointer",
       "@container" : "@set"
-    },
-    "reference" : {
-      "@id" : "rdfpointer:reference",
-      "@type" : "spdx:File"
     },
     "referenceCategory" : {
       "@id" : "spdx:referenceCategory",
@@ -357,11 +375,6 @@
       "@id" : "spdx:reviewer",
       "@type" : "xs:string"
     },
-    "seeAlsos" : {
-      "@id" : "rdfs:seeAlsos",
-      "@type" : "xs:string",
-      "@container" : "@set"
-    },
     "snippetFromFile" : {
       "@id" : "spdx:snippetFromFile",
       "@type" : "spdx:File"
@@ -393,10 +406,6 @@
     "standardLicenseTemplate" : {
       "@id" : "spdx:standardLicenseTemplate",
       "@type" : "xs:string"
-    },
-    "startPointer" : {
-      "@id" : "rdfpointer:startPointer",
-      "@type" : "rdfpointer:SinglePointer"
     },
     "summary" : {
       "@id" : "spdx:summary",

--- a/resources/spdx-2-2-revision-16-onotology.context.json
+++ b/resources/spdx-2-2-revision-16-onotology.context.json
@@ -11,10 +11,6 @@
       "@id" : "spdx:licenseConcluded",
       "@type" : "spdx:AnyLicenseInfo"
     },
-    "referencesFile" : {
-      "@id" : "spdx:referencesFile",
-      "@type" : "spdx:File"
-    },
     "licenseException" : {
       "@id" : "spdx:licenseException",
       "@type" : "spdx:LicenseException"
@@ -31,13 +27,14 @@
       "@id" : "spdx:dataLicense",
       "@type" : "spdx:AnyLicenseInfo"
     },
-    "member" : {
-      "@id" : "rdfs:member"
-    },
     "members" : {
       "@id" : "spdx:members",
       "@type" : "spdx:AnyLicenseInfo",
       "@container" : "@set"
+    },
+    "member" : {
+      "@id" : "spdx:member",
+      "@type" : "spdx:AnyLicenseInfo"
     },
     "algorithm" : {
       "@id" : "spdx:algorithm",
@@ -52,36 +49,25 @@
       "@type" : "spdx:SimpleLicensingInfo",
       "@container" : "@set"
     },
-    "licenseInfoInFile" : {
-      "@id" : "spdx:licenseInfoInFile",
-      "@type" : "spdx:AnyLicenseInfo"
-    },
     "licenseInfoInFiles" : {
       "@id" : "spdx:licenseInfoInFiles",
       "@type" : "spdx:AnyLicenseInfo",
       "@container" : "@set"
-    },
-    "licenseInfoInSnippet" : {
-      "@id" : "spdx:licenseInfoInSnippet",
-      "@type" : "spdx:AnyLicenseInfo"
     },
     "licenseInfoInSnippets" : {
       "@id" : "spdx:licenseInfoInSnippets",
       "@type" : "spdx:AnyLicenseInfo",
       "@container" : "@set"
     },
-    "annotation" : {
-      "@id" : "spdx:annotation",
-      "@type" : "spdx:Annotation"
-    },
     "annotations" : {
       "@id" : "spdx:annotations",
       "@type" : "spdx:Annotation",
       "@container" : "@set"
     },
-    "externalDocumentRef" : {
-      "@id" : "spdx:externalDocumentRef",
-      "@type" : "spdx:ExternalDocumentRef"
+    "crossRefs" : {
+      "@id" : "spdx:crossRefs",
+      "@type" : "spdx:CrossRef",
+      "@container" : "@set"
     },
     "externalDocumentRefs" : {
       "@id" : "spdx:externalDocumentRefs",
@@ -96,10 +82,6 @@
       "@id" : "rdfpointer:reference",
       "@type" : "spdx:File"
     },
-    "reviewed" : {
-      "@id" : "spdx:reviewed",
-      "@type" : "spdx:Review"
-    },
     "revieweds" : {
       "@id" : "spdx:revieweds",
       "@type" : "spdx:Review",
@@ -109,22 +91,18 @@
       "@id" : "spdx:creationInfo",
       "@type" : "spdx:CreationInfo"
     },
-    "checksum" : {
-      "@id" : "spdx:checksum",
-      "@type" : "spdx:Checksum"
-    },
     "checksums" : {
       "@id" : "spdx:checksums",
       "@type" : "spdx:Checksum",
       "@container" : "@set"
     },
+    "checksum" : {
+      "@id" : "spdx:checksum",
+      "@type" : "spdx:Checksum"
+    },
     "annotationType" : {
       "@id" : "spdx:annotationType",
       "@type" : "spdx:AnnotationType"
-    },
-    "describesPackage" : {
-      "@id" : "spdx:describesPackage",
-      "@type" : "spdx:Package"
     },
     "describesPackages" : {
       "@id" : "spdx:describesPackages",
@@ -135,10 +113,6 @@
       "@id" : "spdx:relationshipType",
       "@type" : "spdx:RelationshipType"
     },
-    "hasExtractedLicensingInfo" : {
-      "@id" : "spdx:hasExtractedLicensingInfo",
-      "@type" : "spdx:ExtractedLicensingInfo"
-    },
     "hasExtractedLicensingInfos" : {
       "@id" : "spdx:hasExtractedLicensingInfos",
       "@type" : "spdx:ExtractedLicensingInfo",
@@ -147,10 +121,6 @@
     "spdxDocument" : {
       "@id" : "spdx:spdxDocument",
       "@type" : "spdx:SpdxDocument"
-    },
-    "artifactOf" : {
-      "@id" : "spdx:artifactOf",
-      "@type" : "doap:Project"
     },
     "artifactOfs" : {
       "@id" : "spdx:artifactOfs",
@@ -165,18 +135,10 @@
       "@id" : "spdx:referenceCategory",
       "@type" : "spdx:ReferenceCategory"
     },
-    "range" : {
-      "@id" : "spdx:range",
-      "@type" : "rdfpointer:StartEndPointer"
-    },
     "ranges" : {
       "@id" : "spdx:ranges",
       "@type" : "rdfpointer:StartEndPointer",
       "@container" : "@set"
-    },
-    "externalRef" : {
-      "@id" : "spdx:externalRef",
-      "@type" : "spdx:ExternalRef"
     },
     "externalRefs" : {
       "@id" : "spdx:externalRefs",
@@ -187,18 +149,10 @@
       "@id" : "rdfpointer:endPointer",
       "@type" : "rdfpointer:SinglePointer"
     },
-    "relationship" : {
-      "@id" : "spdx:relationship",
-      "@type" : "spdx:Relationship"
-    },
     "relationships" : {
       "@id" : "spdx:relationships",
       "@type" : "spdx:Relationship",
       "@container" : "@set"
-    },
-    "fileType" : {
-      "@id" : "spdx:fileType",
-      "@type" : "spdx:FileType"
     },
     "fileTypes" : {
       "@id" : "spdx:fileTypes",
@@ -209,18 +163,10 @@
       "@id" : "spdx:licenseDeclared",
       "@type" : "spdx:AnyLicenseInfo"
     },
-    "hasFile" : {
-      "@id" : "spdx:hasFile",
-      "@type" : "spdx:File"
-    },
     "hasFiles" : {
       "@id" : "spdx:hasFiles",
       "@type" : "spdx:File",
       "@container" : "@set"
-    },
-    "fileDependency" : {
-      "@id" : "spdx:fileDependency",
-      "@type" : "spdx:File"
     },
     "fileDependencies" : {
       "@id" : "spdx:fileDependencies",
@@ -267,8 +213,8 @@
       "@id" : "spdx:documentation",
       "@type" : "xs:anyURI"
     },
-    "packageVerificationCodeExcludedFile" : {
-      "@id" : "spdx:packageVerificationCodeExcludedFile",
+    "match" : {
+      "@id" : "spdx:match",
       "@type" : "xs:string"
     },
     "packageVerificationCodeExcludedFiles" : {
@@ -276,33 +222,33 @@
       "@type" : "xs:string",
       "@container" : "@set"
     },
-    "snippetName" : {
-      "@id" : "spdx:snippetName",
-      "@type" : "xs:string"
-    },
     "fileName" : {
       "@id" : "spdx:fileName",
       "@type" : "xs:string"
     },
-    "attributionText" : {
-      "@id" : "spdx:attributionText",
-      "@type" : "xs:string"
+    "order" : {
+      "@id" : "spdx:order",
+      "@type" : "xs:nonNegativeInteger"
+    },
+    "isValid" : {
+      "@id" : "spdx:isValid",
+      "@type" : "xs:boolean"
     },
     "attributionTexts" : {
       "@id" : "spdx:attributionTexts",
       "@type" : "xs:string",
       "@container" : "@set"
     },
-    "packageName" : {
-      "@id" : "spdx:packageName",
-      "@type" : "xs:string"
-    },
     "copyrightText" : {
       "@id" : "spdx:copyrightText",
       "@type" : "xs:string"
     },
-    "specVersion" : {
-      "@id" : "spdx:specVersion",
+    "spdxVersion" : {
+      "@id" : "spdx:spdxVersion",
+      "@type" : "xs:string"
+    },
+    "deprecatedVersion" : {
+      "@id" : "spdx:deprecatedVersion",
       "@type" : "xs:string"
     },
     "isFsfLibre" : {
@@ -317,13 +263,25 @@
       "@id" : "spdx:licenseText",
       "@type" : "xs:string"
     },
+    "licenseTextHtml" : {
+      "@id" : "spdx:licenseTextHtml",
+      "@type" : "xs:string"
+    },
+    "licenseExceptionTemplate" : {
+      "@id" : "spdx:licenseExceptionTemplate",
+      "@type" : "xs:string"
+    },
+    "exceptionTextHtml" : {
+      "@id" : "spdx:exceptionTextHtml",
+      "@type" : "xs:string"
+    },
     "description" : {
       "@id" : "spdx:description",
       "@type" : "xs:string"
     },
-    "seeAlso" : {
-      "@id" : "rdfs:seeAlso",
-      "@type" : "xs:string"
+    "isLive" : {
+      "@id" : "spdx:isLive",
+      "@type" : "xs:boolean"
     },
     "seeAlsos" : {
       "@id" : "rdfs:seeAlsos",
@@ -336,7 +294,7 @@
     },
     "contextualExample" : {
       "@id" : "spdx:contextualExample",
-      "@type" : "xs:string"
+      "@type" : "xs:anyURI"
     },
     "summary" : {
       "@id" : "spdx:summary",
@@ -366,12 +324,12 @@
       "@id" : "rdfpointer:offset",
       "@type" : "xs:positiveInteger"
     },
-    "spdxVersion" : {
-      "@id" : "spdx:spdxVersion",
-      "@type" : "xs:string"
+    "isWayBackLink" : {
+      "@id" : "spdx:isWayBackLink",
+      "@type" : "xs:boolean"
     },
-    "date" : {
-      "@id" : "spdx:date",
+    "timestamp" : {
+      "@id" : "spdx:timestamp",
       "@type" : "xs:dateTime"
     },
     "annotationDate" : {
@@ -380,10 +338,6 @@
     },
     "example" : {
       "@id" : "spdx:example",
-      "@type" : "xs:string"
-    },
-    "fileContributor" : {
-      "@id" : "spdx:fileContributor",
       "@type" : "xs:string"
     },
     "fileContributors" : {
@@ -395,9 +349,13 @@
       "@id" : "spdx:licenseId",
       "@type" : "xs:string"
     },
+    "url" : {
+      "@id" : "spdx:url",
+      "@type" : "xs:anyURI"
+    },
     "referenceLocator" : {
       "@id" : "spdx:referenceLocator",
-      "@type" : "xs:string"
+      "@type" : "xs:anyURI"
     },
     "packageVerificationCodeValue" : {
       "@id" : "spdx:packageVerificationCodeValue",
@@ -431,6 +389,10 @@
       "@id" : "spdx:packageFileName",
       "@type" : "xs:string"
     },
+    "standardLicenseHeaderHtml" : {
+      "@id" : "spdx:standardLicenseHeaderHtml",
+      "@type" : "xs:string"
+    },
     "licenseComments" : {
       "@id" : "spdx:licenseComments",
       "@type" : "xs:string"
@@ -444,10 +406,6 @@
       "@type" : "xs:string"
     },
     "externalDocumentId" : "@id",
-    "creator" : {
-      "@id" : "spdx:creator",
-      "@type" : "xs:string"
-    },
     "creators" : {
       "@id" : "spdx:creators",
       "@type" : "xs:string",
@@ -460,15 +418,6 @@
     "isOsiApproved" : {
       "@id" : "spdx:isOsiApproved",
       "@type" : "xs:boolean"
-    },
-    "term_status" : {
-      "@id" : "http://www.w3.org/2003/06/sw-vocab-status/ns#term_status"
-    },
-    "deprecatedProperty" : {
-      "@id" : "owl:deprecatedProperty"
-    },
-    "deprecatedClass" : {
-      "@id" : "owl:deprecatedClass"
     },
     "Document" : {
       "@type" : "spdx:SpdxDocument",

--- a/resources/spdx-2-2-revision-16-onotology.context.json
+++ b/resources/spdx-2-2-revision-16-onotology.context.json
@@ -7,42 +7,236 @@
     "rdfpointer" : "http://www.w3.org/2009/pointers#",
     "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
     "xs" : "http://www.w3.org/2001/XMLSchema#",
+    "Document" : {
+      "@type" : "spdx:SpdxDocument",
+      "@id" : "spdx:spdxDocument"
+    },
+    "SPDXID" : "@id",
+    "externalDocumentId" : {
+      "@id" : "spdx:externalDocumentId",
+      "@type" : "xs:anyURI"
+    },
+    "algorithm" : {
+      "@id" : "spdx:algorithm",
+      "@type" : "spdx:ChecksumAlgorithm"
+    },
+    "annotations" : {
+      "@id" : "spdx:annotations",
+      "@type" : "spdx:Annotation",
+      "@container" : "@set"
+    },
+    "annotationDate" : {
+      "@id" : "spdx:annotationDate",
+      "@type" : "xs:dateTime"
+    },
+    "annotationType" : {
+      "@id" : "spdx:annotationType",
+      "@type" : "spdx:AnnotationType"
+    },
+    "annotator" : {
+      "@id" : "spdx:annotator",
+      "@type" : "xs:string"
+    },
+    "artifactOfs" : {
+      "@id" : "spdx:artifactOfs",
+      "@type" : "doap:Project",
+      "@container" : "@set"
+    },
+    "attributionTexts" : {
+      "@id" : "spdx:attributionTexts",
+      "@type" : "xs:string",
+      "@container" : "@set"
+    },
+    "checksums" : {
+      "@id" : "spdx:checksums",
+      "@type" : "spdx:Checksum",
+      "@container" : "@set"
+    },
+    "checksum" : {
+      "@id" : "spdx:checksum",
+      "@type" : "spdx:Checksum"
+    },
+    "checksumValue" : {
+      "@id" : "spdx:checksumValue",
+      "@type" : "xs:hexBinary"
+    },
+    "comment" : {
+      "@id" : "rdfs:comment",
+      "@type" : "xs:string"
+    },
+    "contextualExample" : {
+      "@id" : "spdx:contextualExample",
+      "@type" : "xs:anyURI"
+    },
+    "copyrightText" : {
+      "@id" : "spdx:copyrightText",
+      "@type" : "xs:string"
+    },
+    "created" : {
+      "@id" : "spdx:created",
+      "@type" : "xs:dateTime"
+    },
+    "creationInfo" : {
+      "@id" : "spdx:creationInfo",
+      "@type" : "spdx:CreationInfo"
+    },
+    "creators" : {
+      "@id" : "spdx:creators",
+      "@type" : "xs:string",
+      "@container" : "@set"
+    },
+    "crossRefs" : {
+      "@id" : "spdx:crossRefs",
+      "@type" : "spdx:CrossRef",
+      "@container" : "@set"
+    },
+    "dataLicense" : {
+      "@id" : "spdx:dataLicense",
+      "@type" : "spdx:AnyLicenseInfo"
+    },
+    "deprecatedVersion" : {
+      "@id" : "spdx:deprecatedVersion",
+      "@type" : "xs:string"
+    },
+    "describesPackages" : {
+      "@id" : "spdx:describesPackages",
+      "@type" : "spdx:Package",
+      "@container" : "@set"
+    },
+    "description" : {
+      "@id" : "spdx:description",
+      "@type" : "xs:string"
+    },
+    "documentation" : {
+      "@id" : "spdx:documentation",
+      "@type" : "xs:anyURI"
+    },
+    "downloadLocation" : {
+      "@id" : "spdx:downloadLocation",
+      "@type" : "xs:anyURI"
+    },
+    "endPointer" : {
+      "@id" : "rdfpointer:endPointer",
+      "@type" : "rdfpointer:SinglePointer"
+    },
+    "example" : {
+      "@id" : "spdx:example",
+      "@type" : "xs:string"
+    },
+    "exceptionTextHtml" : {
+      "@id" : "spdx:exceptionTextHtml",
+      "@type" : "xs:string"
+    },
+    "externalDocumentRefs" : {
+      "@id" : "spdx:externalDocumentRefs",
+      "@type" : "spdx:ExternalDocumentRef",
+      "@container" : "@set"
+    },
+    "externalRefs" : {
+      "@id" : "spdx:externalRefs",
+      "@type" : "spdx:ExternalRef",
+      "@container" : "@set"
+    },
+    "externalReferenceSite" : {
+      "@id" : "spdx:externalReferenceSite",
+      "@type" : "xs:anyURI"
+    },
+    "extractedText" : {
+      "@id" : "spdx:extractedText",
+      "@type" : "xs:string"
+    },
+    "fileContributors" : {
+      "@id" : "spdx:fileContributors",
+      "@type" : "xs:string",
+      "@container" : "@set"
+    },
+    "fileDependencies" : {
+      "@id" : "spdx:fileDependencies",
+      "@type" : "spdx:File",
+      "@container" : "@set"
+    },
+    "fileName" : {
+      "@id" : "spdx:fileName",
+      "@type" : "xs:string"
+    },
+    "fileTypes" : {
+      "@id" : "spdx:fileTypes",
+      "@type" : "spdx:FileType",
+      "@container" : "@set"
+    },
+    "filesAnalyzed" : {
+      "@id" : "spdx:filesAnalyzed",
+      "@type" : "xs:boolean"
+    },
+    "hasExtractedLicensingInfos" : {
+      "@id" : "spdx:hasExtractedLicensingInfos",
+      "@type" : "spdx:ExtractedLicensingInfo",
+      "@container" : "@set"
+    },
+    "hasFiles" : {
+      "@id" : "spdx:hasFiles",
+      "@type" : "spdx:File",
+      "@container" : "@set"
+    },
+    "homepage" : {
+      "@id" : "doap:homepage",
+      "@type" : "xs:anyURI"
+    },
+    "isDeprecatedLicenseId" : {
+      "@id" : "spdx:isDeprecatedLicenseId",
+      "@type" : "xs:boolean"
+    },
+    "isFsfLibre" : {
+      "@id" : "spdx:isFsfLibre",
+      "@type" : "xs:boolean"
+    },
+    "isLive" : {
+      "@id" : "spdx:isLive",
+      "@type" : "xs:boolean"
+    },
+    "isOsiApproved" : {
+      "@id" : "spdx:isOsiApproved",
+      "@type" : "xs:boolean"
+    },
+    "isValid" : {
+      "@id" : "spdx:isValid",
+      "@type" : "xs:boolean"
+    },
+    "isWayBackLink" : {
+      "@id" : "spdx:isWayBackLink",
+      "@type" : "xs:boolean"
+    },
+    "licenseComments" : {
+      "@id" : "spdx:licenseComments",
+      "@type" : "xs:string"
+    },
     "licenseConcluded" : {
       "@id" : "spdx:licenseConcluded",
+      "@type" : "spdx:AnyLicenseInfo"
+    },
+    "licenseDeclared" : {
+      "@id" : "spdx:licenseDeclared",
       "@type" : "spdx:AnyLicenseInfo"
     },
     "licenseException" : {
       "@id" : "spdx:licenseException",
       "@type" : "spdx:LicenseException"
     },
-    "referenceType" : {
-      "@id" : "spdx:referenceType",
-      "@type" : "spdx:ReferenceType"
+    "licenseExceptionId" : {
+      "@id" : "spdx:licenseExceptionId",
+      "@type" : "xs:string"
     },
-    "packageVerificationCode" : {
-      "@id" : "spdx:packageVerificationCode",
-      "@type" : "spdx:PackageVerificationCode"
+    "licenseExceptionTemplate" : {
+      "@id" : "spdx:licenseExceptionTemplate",
+      "@type" : "xs:string"
     },
-    "dataLicense" : {
-      "@id" : "spdx:dataLicense",
-      "@type" : "spdx:AnyLicenseInfo"
+    "licenseExceptionText" : {
+      "@id" : "spdx:licenseExceptionText",
+      "@type" : "xs:string"
     },
-    "members" : {
-      "@id" : "spdx:members",
-      "@type" : "spdx:AnyLicenseInfo",
-      "@container" : "@set"
-    },
-    "member" : {
-      "@id" : "spdx:member",
-      "@type" : "spdx:AnyLicenseInfo"
-    },
-    "algorithm" : {
-      "@id" : "spdx:algorithm",
-      "@type" : "spdx:ChecksumAlgorithm"
-    },
-    "relatedSpdxElement" : {
-      "@id" : "spdx:relatedSpdxElement",
-      "@type" : "spdx:SpdxElement"
+    "licenseId" : {
+      "@id" : "spdx:licenseId",
+      "@type" : "xs:string"
     },
     "licenseInfoFromFiles" : {
       "@id" : "spdx:licenseInfoFromFiles",
@@ -59,204 +253,8 @@
       "@type" : "spdx:AnyLicenseInfo",
       "@container" : "@set"
     },
-    "annotations" : {
-      "@id" : "spdx:annotations",
-      "@type" : "spdx:Annotation",
-      "@container" : "@set"
-    },
-    "crossRefs" : {
-      "@id" : "spdx:crossRefs",
-      "@type" : "spdx:CrossRef",
-      "@container" : "@set"
-    },
-    "externalDocumentRefs" : {
-      "@id" : "spdx:externalDocumentRefs",
-      "@type" : "spdx:ExternalDocumentRef",
-      "@container" : "@set"
-    },
-    "startPointer" : {
-      "@id" : "rdfpointer:startPointer",
-      "@type" : "rdfpointer:SinglePointer"
-    },
-    "reference" : {
-      "@id" : "rdfpointer:reference",
-      "@type" : "spdx:File"
-    },
-    "revieweds" : {
-      "@id" : "spdx:revieweds",
-      "@type" : "spdx:Review",
-      "@container" : "@set"
-    },
-    "creationInfo" : {
-      "@id" : "spdx:creationInfo",
-      "@type" : "spdx:CreationInfo"
-    },
-    "checksums" : {
-      "@id" : "spdx:checksums",
-      "@type" : "spdx:Checksum",
-      "@container" : "@set"
-    },
-    "checksum" : {
-      "@id" : "spdx:checksum",
-      "@type" : "spdx:Checksum"
-    },
-    "annotationType" : {
-      "@id" : "spdx:annotationType",
-      "@type" : "spdx:AnnotationType"
-    },
-    "describesPackages" : {
-      "@id" : "spdx:describesPackages",
-      "@type" : "spdx:Package",
-      "@container" : "@set"
-    },
-    "relationshipType" : {
-      "@id" : "spdx:relationshipType",
-      "@type" : "spdx:RelationshipType"
-    },
-    "hasExtractedLicensingInfos" : {
-      "@id" : "spdx:hasExtractedLicensingInfos",
-      "@type" : "spdx:ExtractedLicensingInfo",
-      "@container" : "@set"
-    },
-    "spdxDocument" : {
-      "@id" : "spdx:spdxDocument",
-      "@type" : "spdx:SpdxDocument"
-    },
-    "artifactOfs" : {
-      "@id" : "spdx:artifactOfs",
-      "@type" : "doap:Project",
-      "@container" : "@set"
-    },
-    "snippetFromFile" : {
-      "@id" : "spdx:snippetFromFile",
-      "@type" : "spdx:File"
-    },
-    "referenceCategory" : {
-      "@id" : "spdx:referenceCategory",
-      "@type" : "spdx:ReferenceCategory"
-    },
-    "ranges" : {
-      "@id" : "spdx:ranges",
-      "@type" : "rdfpointer:StartEndPointer",
-      "@container" : "@set"
-    },
-    "externalRefs" : {
-      "@id" : "spdx:externalRefs",
-      "@type" : "spdx:ExternalRef",
-      "@container" : "@set"
-    },
-    "endPointer" : {
-      "@id" : "rdfpointer:endPointer",
-      "@type" : "rdfpointer:SinglePointer"
-    },
-    "relationships" : {
-      "@id" : "spdx:relationships",
-      "@type" : "spdx:Relationship",
-      "@container" : "@set"
-    },
-    "fileTypes" : {
-      "@id" : "spdx:fileTypes",
-      "@type" : "spdx:FileType",
-      "@container" : "@set"
-    },
-    "licenseDeclared" : {
-      "@id" : "spdx:licenseDeclared",
-      "@type" : "spdx:AnyLicenseInfo"
-    },
-    "hasFiles" : {
-      "@id" : "spdx:hasFiles",
-      "@type" : "spdx:File",
-      "@container" : "@set"
-    },
-    "fileDependencies" : {
-      "@id" : "spdx:fileDependencies",
-      "@type" : "spdx:File",
-      "@container" : "@set"
-    },
-    "sourceInfo" : {
-      "@id" : "spdx:sourceInfo",
-      "@type" : "xs:string"
-    },
-    "noticeText" : {
-      "@id" : "spdx:noticeText",
-      "@type" : "xs:string"
-    },
-    "standardLicenseTemplate" : {
-      "@id" : "spdx:standardLicenseTemplate",
-      "@type" : "xs:string"
-    },
-    "name" : {
-      "@id" : "spdx:name",
-      "@type" : "xs:string"
-    },
-    "checksumValue" : {
-      "@id" : "spdx:checksumValue",
-      "@type" : "xs:hexBinary"
-    },
-    "extractedText" : {
-      "@id" : "spdx:extractedText",
-      "@type" : "xs:string"
-    },
-    "standardLicenseHeader" : {
-      "@id" : "spdx:standardLicenseHeader",
-      "@type" : "xs:string"
-    },
-    "reviewer" : {
-      "@id" : "spdx:reviewer",
-      "@type" : "xs:string"
-    },
     "licenseListVersion" : {
       "@id" : "spdx:licenseListVersion",
-      "@type" : "xs:string"
-    },
-    "documentation" : {
-      "@id" : "spdx:documentation",
-      "@type" : "xs:anyURI"
-    },
-    "match" : {
-      "@id" : "spdx:match",
-      "@type" : "xs:string"
-    },
-    "packageVerificationCodeExcludedFiles" : {
-      "@id" : "spdx:packageVerificationCodeExcludedFiles",
-      "@type" : "xs:string",
-      "@container" : "@set"
-    },
-    "fileName" : {
-      "@id" : "spdx:fileName",
-      "@type" : "xs:string"
-    },
-    "order" : {
-      "@id" : "spdx:order",
-      "@type" : "xs:nonNegativeInteger"
-    },
-    "isValid" : {
-      "@id" : "spdx:isValid",
-      "@type" : "xs:boolean"
-    },
-    "attributionTexts" : {
-      "@id" : "spdx:attributionTexts",
-      "@type" : "xs:string",
-      "@container" : "@set"
-    },
-    "copyrightText" : {
-      "@id" : "spdx:copyrightText",
-      "@type" : "xs:string"
-    },
-    "spdxVersion" : {
-      "@id" : "spdx:spdxVersion",
-      "@type" : "xs:string"
-    },
-    "deprecatedVersion" : {
-      "@id" : "spdx:deprecatedVersion",
-      "@type" : "xs:string"
-    },
-    "isFsfLibre" : {
-      "@id" : "spdx:isFsfLibre",
-      "@type" : "xs:boolean"
-    },
-    "comment" : {
-      "@id" : "rdfs:comment",
       "@type" : "xs:string"
     },
     "licenseText" : {
@@ -267,162 +265,158 @@
       "@id" : "spdx:licenseTextHtml",
       "@type" : "xs:string"
     },
-    "licenseExceptionTemplate" : {
-      "@id" : "spdx:licenseExceptionTemplate",
-      "@type" : "xs:string"
-    },
-    "exceptionTextHtml" : {
-      "@id" : "spdx:exceptionTextHtml",
-      "@type" : "xs:string"
-    },
-    "description" : {
-      "@id" : "spdx:description",
-      "@type" : "xs:string"
-    },
-    "isLive" : {
-      "@id" : "spdx:isLive",
-      "@type" : "xs:boolean"
-    },
-    "seeAlsos" : {
-      "@id" : "rdfs:seeAlsos",
-      "@type" : "xs:string",
-      "@container" : "@set"
-    },
-    "licenseExceptionText" : {
-      "@id" : "spdx:licenseExceptionText",
-      "@type" : "xs:string"
-    },
-    "contextualExample" : {
-      "@id" : "spdx:contextualExample",
-      "@type" : "xs:anyURI"
-    },
-    "summary" : {
-      "@id" : "spdx:summary",
-      "@type" : "xs:string"
-    },
-    "externalReferenceSite" : {
-      "@id" : "spdx:externalReferenceSite",
-      "@type" : "xs:anyURI"
-    },
-    "filesAnalyzed" : {
-      "@id" : "spdx:filesAnalyzed",
-      "@type" : "xs:boolean"
-    },
-    "versionInfo" : {
-      "@id" : "spdx:versionInfo",
-      "@type" : "xs:string"
-    },
-    "created" : {
-      "@id" : "spdx:created",
-      "@type" : "xs:dateTime"
-    },
     "lineNumber" : {
       "@id" : "rdfpointer:lineNumber",
       "@type" : "xs:positiveInteger"
+    },
+    "match" : {
+      "@id" : "spdx:match",
+      "@type" : "xs:string"
+    },
+    "name" : {
+      "@id" : "spdx:name",
+      "@type" : "xs:string"
+    },
+    "noticeText" : {
+      "@id" : "spdx:noticeText",
+      "@type" : "xs:string"
     },
     "offset" : {
       "@id" : "rdfpointer:offset",
       "@type" : "xs:positiveInteger"
     },
-    "isWayBackLink" : {
-      "@id" : "spdx:isWayBackLink",
-      "@type" : "xs:boolean"
+    "order" : {
+      "@id" : "spdx:order",
+      "@type" : "xs:nonNegativeInteger"
     },
-    "timestamp" : {
-      "@id" : "spdx:timestamp",
-      "@type" : "xs:dateTime"
-    },
-    "annotationDate" : {
-      "@id" : "spdx:annotationDate",
-      "@type" : "xs:dateTime"
-    },
-    "example" : {
-      "@id" : "spdx:example",
-      "@type" : "xs:string"
-    },
-    "fileContributors" : {
-      "@id" : "spdx:fileContributors",
-      "@type" : "xs:string",
-      "@container" : "@set"
-    },
-    "licenseId" : {
-      "@id" : "spdx:licenseId",
-      "@type" : "xs:string"
-    },
-    "url" : {
-      "@id" : "spdx:url",
-      "@type" : "xs:anyURI"
-    },
-    "referenceLocator" : {
-      "@id" : "spdx:referenceLocator",
-      "@type" : "xs:anyURI"
-    },
-    "packageVerificationCodeValue" : {
-      "@id" : "spdx:packageVerificationCodeValue",
-      "@type" : "xs:hexBinary"
-    },
-    "isDeprecatedLicenseId" : {
-      "@id" : "spdx:isDeprecatedLicenseId",
-      "@type" : "xs:boolean"
-    },
-    "homepage" : {
-      "@id" : "doap:homepage",
-      "@type" : "xs:anyURI"
-    },
-    "supplier" : {
-      "@id" : "spdx:supplier",
-      "@type" : "xs:string"
-    },
-    "reviewDate" : {
-      "@id" : "spdx:reviewDate",
-      "@type" : "xs:dateTime"
-    },
-    "licenseExceptionId" : {
-      "@id" : "spdx:licenseExceptionId",
-      "@type" : "xs:string"
-    },
-    "standardLicenseHeaderTemplate" : {
-      "@id" : "spdx:standardLicenseHeaderTemplate",
+    "originator" : {
+      "@id" : "spdx:originator",
       "@type" : "xs:string"
     },
     "packageFileName" : {
       "@id" : "spdx:packageFileName",
       "@type" : "xs:string"
     },
+    "packageVerificationCode" : {
+      "@id" : "spdx:packageVerificationCode",
+      "@type" : "spdx:PackageVerificationCode"
+    },
+    "packageVerificationCodeExcludedFiles" : {
+      "@id" : "spdx:packageVerificationCodeExcludedFiles",
+      "@type" : "xs:string",
+      "@container" : "@set"
+    },
+    "packageVerificationCodeValue" : {
+      "@id" : "spdx:packageVerificationCodeValue",
+      "@type" : "xs:hexBinary"
+    },
+    "ranges" : {
+      "@id" : "spdx:ranges",
+      "@type" : "rdfpointer:StartEndPointer",
+      "@container" : "@set"
+    },
+    "reference" : {
+      "@id" : "rdfpointer:reference",
+      "@type" : "spdx:File"
+    },
+    "referenceCategory" : {
+      "@id" : "spdx:referenceCategory",
+      "@type" : "spdx:ReferenceCategory"
+    },
+    "referenceLocator" : {
+      "@id" : "spdx:referenceLocator",
+      "@type" : "xs:anyURI"
+    },
+    "referenceType" : {
+      "@id" : "spdx:referenceType",
+      "@type" : "spdx:ReferenceType"
+    },
+    "relatedSpdxElement" : {
+      "@id" : "spdx:relatedSpdxElement",
+      "@type" : "spdx:SpdxElement"
+    },
+    "relationships" : {
+      "@id" : "spdx:relationships",
+      "@type" : "spdx:Relationship",
+      "@container" : "@set"
+    },
+    "relationshipType" : {
+      "@id" : "spdx:relationshipType",
+      "@type" : "spdx:RelationshipType"
+    },
+    "reviewDate" : {
+      "@id" : "spdx:reviewDate",
+      "@type" : "xs:dateTime"
+    },
+    "revieweds" : {
+      "@id" : "spdx:revieweds",
+      "@type" : "spdx:Review",
+      "@container" : "@set"
+    },
+    "reviewer" : {
+      "@id" : "spdx:reviewer",
+      "@type" : "xs:string"
+    },
+    "seeAlsos" : {
+      "@id" : "rdfs:seeAlsos",
+      "@type" : "xs:string",
+      "@container" : "@set"
+    },
+    "snippetFromFile" : {
+      "@id" : "spdx:snippetFromFile",
+      "@type" : "spdx:File"
+    },
+    "sourceInfo" : {
+      "@id" : "spdx:sourceInfo",
+      "@type" : "xs:string"
+    },
+    "spdxDocument" : {
+      "@id" : "spdx:spdxDocument",
+      "@type" : "spdx:SpdxDocument"
+    },
+    "spdxVersion" : {
+      "@id" : "spdx:spdxVersion",
+      "@type" : "xs:string"
+    },
+    "standardLicenseHeader" : {
+      "@id" : "spdx:standardLicenseHeader",
+      "@type" : "xs:string"
+    },
     "standardLicenseHeaderHtml" : {
       "@id" : "spdx:standardLicenseHeaderHtml",
       "@type" : "xs:string"
     },
-    "licenseComments" : {
-      "@id" : "spdx:licenseComments",
+    "standardLicenseHeaderTemplate" : {
+      "@id" : "spdx:standardLicenseHeaderTemplate",
       "@type" : "xs:string"
     },
-    "downloadLocation" : {
-      "@id" : "spdx:downloadLocation",
+    "standardLicenseTemplate" : {
+      "@id" : "spdx:standardLicenseTemplate",
+      "@type" : "xs:string"
+    },
+    "startPointer" : {
+      "@id" : "rdfpointer:startPointer",
+      "@type" : "rdfpointer:SinglePointer"
+    },
+    "summary" : {
+      "@id" : "spdx:summary",
+      "@type" : "xs:string"
+    },
+    "supplier" : {
+      "@id" : "spdx:supplier",
+      "@type" : "xs:string"
+    },
+    "timestamp" : {
+      "@id" : "spdx:timestamp",
+      "@type" : "xs:dateTime"
+    },
+    "url" : {
+      "@id" : "spdx:url",
       "@type" : "xs:anyURI"
     },
-    "originator" : {
-      "@id" : "spdx:originator",
+    "versionInfo" : {
+      "@id" : "spdx:versionInfo",
       "@type" : "xs:string"
-    },
-    "externalDocumentId" : "@id",
-    "creators" : {
-      "@id" : "spdx:creators",
-      "@type" : "xs:string",
-      "@container" : "@set"
-    },
-    "annotator" : {
-      "@id" : "spdx:annotator",
-      "@type" : "xs:string"
-    },
-    "isOsiApproved" : {
-      "@id" : "spdx:isOsiApproved",
-      "@type" : "xs:boolean"
-    },
-    "Document" : {
-      "@type" : "spdx:SpdxDocument",
-      "@id" : "spdx:spdxDocument"
-    },
-    "SPDXID" : "@id"
+    }
   }
 }

--- a/src/main/java/org/spdx/jacksonstore/JacksonDeSerializer.java
+++ b/src/main/java/org/spdx/jacksonstore/JacksonDeSerializer.java
@@ -352,7 +352,8 @@ public class JacksonDeSerializer {
 			Map<String, String> spdxIdProperties, boolean list) throws InvalidSPDXAnalysisException {
 		if (SpdxJsonLDContext.getInstance().isList(property)) {
 			list = true;
-		}if (JsonNodeType.ARRAY.equals(value.getNodeType())) {
+		}
+		if (JsonNodeType.ARRAY.equals(value.getNodeType())) {
 			Iterator<JsonNode> iter = value.elements();
 			while (iter.hasNext()) {
 				setPropertyValueForJsonNode(documentUri, id, property, iter.next(), spdxIdProperties, true);

--- a/src/main/java/org/spdx/jacksonstore/JacksonSerializer.java
+++ b/src/main/java/org/spdx/jacksonstore/JacksonSerializer.java
@@ -174,8 +174,8 @@ public class JacksonSerializer {
 			if (IdType.SpdxId.equals(idType)) {
 				retval.put(SpdxConstants.SPDX_IDENTIFIER, storedItem.getId());
 			} else if (!IdType.Anonymous.equals(idType)) {
-				logger.error("Invalid ID "+storedItem.getId()+".  Must be an SPDX Identifier or Anonomous");
-				throw new InvalidSPDXAnalysisException("Invalid ID "+storedItem.getId()+".  Must be an SPDX Identifier or Anonomous");
+				logger.error("Invalid ID "+storedItem.getId()+".  Must be an SPDX Identifier or Anonymous");
+				throw new InvalidSPDXAnalysisException("Invalid ID "+storedItem.getId()+".  Must be an SPDX Identifier or Anonymous");
 			}
 		} else if (ExternalDocumentRef.class.isAssignableFrom(clazz)) {
 			retval.put(SpdxConstants.EXTERNAL_DOCUMENT_REF_IDENTIFIER, storedItem.getId());

--- a/src/main/java/org/spdx/jacksonstore/SpdxJsonLDContext.java
+++ b/src/main/java/org/spdx/jacksonstore/SpdxJsonLDContext.java
@@ -108,7 +108,7 @@ public class SpdxJsonLDContext {
 	}
 	
 	static private SpdxJsonLDContext instance;
-	static final String JSON_LD_PATH = "/resources/spdx-2-2-revision-10-onotology.context.json";
+	static final String JSON_LD_PATH = "/resources/spdx-2-2-revision-16-onotology.context.json";
 	static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 	private JsonNode contexts;
 	

--- a/src/test/java/org/spdx/jacksonstore/MultiFormatStoreTest.java
+++ b/src/test/java/org/spdx/jacksonstore/MultiFormatStoreTest.java
@@ -21,11 +21,11 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import org.spdx.jacksonstore.MultiFormatStore;
 import org.spdx.jacksonstore.MultiFormatStore.Format;
 import org.spdx.library.InvalidSPDXAnalysisException;
 import org.spdx.library.model.SpdxDocument;
@@ -42,7 +42,8 @@ import junit.framework.TestCase;
 public class MultiFormatStoreTest extends TestCase {
 	
 	static final String JSON_FILE_PATH = "testResources" + File.separator + "SPDXJSONExample-v2.2.spdx.json";
-
+	// This is a copy of SPDXJSONExample-v2.2.spdx.json with relationships property renamed to relationship
+	static final String SINGULAR_RELATIONSHIP_FILE_PATH = "testResources" + File.separator + "SingularRelationship.json";
 	/* (non-Javadoc)
 	 * @see junit.framework.TestCase#setUp()
 	 */
@@ -167,6 +168,18 @@ public class MultiFormatStoreTest extends TestCase {
 		assertTrue(comparer.isDocumentRelationshipsEquals());
 		assertFalse(comparer.isDifferenceFound());
 		assertTrue(inputDocument.equivalent(compareDocument));
+	}
+	
+	// Test for issue #21 Validation accepts invalid SPDX YAML files
+	public void testSingularRelationship() throws FileNotFoundException, IOException, InvalidSPDXAnalysisException {
+	    File jsonFile = new File(SINGULAR_RELATIONSHIP_FILE_PATH);
+        MultiFormatStore inputStore = new MultiFormatStore(new InMemSpdxStore(), Format.JSON_PRETTY);
+        try (InputStream input = new FileInputStream(jsonFile)) {
+            inputStore.deSerialize(input, false);
+            fail("Singular relationship property should not succeed");
+        } catch(InvalidSPDXAnalysisException ex) {
+            // expected
+        }
 	}
 
 }

--- a/testResources/SingularRelationship.json
+++ b/testResources/SingularRelationship.json
@@ -1,0 +1,279 @@
+{
+  "SPDXID" : "SPDXRef-DOCUMENT",
+  "spdxVersion" : "SPDX-2.2",
+  "creationInfo" : {
+    "comment" : "This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries.",
+    "created" : "2010-01-29T18:30:22Z",
+    "creators" : [ "Tool: LicenseFind-1.0", "Organization: ExampleCodeInspect ()", "Person: Jane Doe ()" ],
+    "licenseListVersion" : "3.9"
+  },
+  "name" : "SPDX-Tools-v2.0",
+  "dataLicense" : "CC0-1.0",
+  "comment" : "This document was created using SPDX 2.0 using licenses from the web site.",
+  "externalDocumentRefs" : [ {
+    "externalDocumentId" : "DocumentRef-spdx-tool-1.2",
+    "checksum" : {
+      "algorithm" : "SHA1",
+      "checksumValue" : "d6a770ba38583ed4bb4525bd96e50461655d2759"
+    },
+    "spdxDocument" : "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+  } ],
+  "hasExtractedLicensingInfos" : [ {
+    "extractedText" : "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote this file. As long as you retain this notice you\ncan do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp  </\nLicenseName: Beer-Ware License (Version 42)\nLicenseCrossReference:  http://people.freebsd.org/~phk/\nLicenseComment: \nThe beerware license has a couple of other standard variants.",
+    "licenseId" : "LicenseRef-Beerware-4.2"
+  }, {
+    "extractedText" : "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/",
+    "licenseId" : "LicenseRef-4"
+  }, {
+    "comment" : "This is tye CyperNeko License",
+    "extractedText" : "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
+    "licenseId" : "LicenseRef-3",
+    "name" : "CyberNeko License",
+    "seeAlsos" : [ "http://people.apache.org/~andyc/neko/LICENSE", "http://justasample.url.com" ]
+  }, {
+    "extractedText" : "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n� Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
+    "licenseId" : "LicenseRef-2"
+  }, {
+    "extractedText" : "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/",
+    "licenseId" : "LicenseRef-1"
+  } ],
+  "annotations" : [ {
+    "annotationDate" : "2010-01-29T18:30:22Z",
+    "annotationType" : "OTHER",
+    "annotator" : "Person: Jane Doe ()",
+    "comment" : "Document level annotation"
+  }, {
+    "annotationDate" : "2011-03-13T00:00:00Z",
+    "annotationType" : "REVIEW",
+    "annotator" : "Person: Suzanne Reviewer",
+    "comment" : "Another example reviewer."
+  }, {
+    "annotationDate" : "2010-02-10T00:00:00Z",
+    "annotationType" : "REVIEW",
+    "annotator" : "Person: Joe Reviewer",
+    "comment" : "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses"
+  } ],
+  "documentNamespace" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301",
+  "documentDescribes" : [ "SPDXRef-File", "SPDXRef-Package" ],
+  "packages" : [ {
+    "SPDXID" : "SPDXRef-Package",
+    "annotations" : [ {
+      "annotationDate" : "2011-01-29T18:30:22Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Person: Package Commenter",
+      "comment" : "Package level annotation"
+    } ],
+    "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+    }, {
+      "algorithm" : "MD5",
+      "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
+    }, {
+      "algorithm" : "SHA256",
+      "checksumValue" : "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
+    } ],
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "description" : "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
+    "downloadLocation" : "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
+    "externalRefs" : [ {
+      "comment" : "This is the external ref for Acme",
+      "referenceCategory" : "OTHER",
+      "referenceLocator" : "acmecorp/acmenator/4.1.3-alpha",
+      "referenceType" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
+    }, {
+      "referenceCategory" : "SECURITY",
+      "referenceLocator" : "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
+      "referenceType" : "http://spdx.org/rdf/references/cpe23Type"
+    } ],
+    "filesAnalyzed" : true,
+    "hasFiles" : [ "SPDXRef-JenaLib", "SPDXRef-DoapSource", "SPDXRef-CommonsLangSrc" ],
+    "homepage" : "http://ftp.gnu.org/gnu/glibc",
+    "licenseComments" : "The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.",
+    "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-3)",
+    "licenseDeclared" : "(LGPL-2.0-only AND LicenseRef-3)",
+    "licenseInfoFromFiles" : [ "GPL-2.0-only", "LicenseRef-2", "LicenseRef-1" ],
+    "name" : "glibc",
+    "originator" : "Organization: ExampleCodeInspect (contact@example.com)",
+    "packageFileName" : "glibc-2.11.1.tar.gz",
+    "packageVerificationCode" : {
+      "packageVerificationCodeExcludedFiles" : [ "./package.spdx" ],
+      "packageVerificationCodeValue" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    },
+    "sourceInfo" : "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.",
+    "summary" : "GNU C library.",
+    "supplier" : "Person: Jane Doe (jane.doe@example.com)",
+    "versionInfo" : "2.11.1"
+  }, {
+    "SPDXID" : "SPDXRef-fromDoap-1",
+    "comment" : "This package was converted from a DOAP Project by the same name",
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "filesAnalyzed" : false,
+    "homepage" : "http://commons.apache.org/proper/commons-lang/",
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "Apache Commons Lang"
+  }, {
+    "SPDXID" : "SPDXRef-fromDoap-0",
+    "comment" : "This package was converted from a DOAP Project by the same name",
+    "copyrightText" : "NOASSERTION",
+    "downloadLocation" : "NOASSERTION",
+    "filesAnalyzed" : false,
+    "homepage" : "http://www.openjena.org/",
+    "licenseConcluded" : "NOASSERTION",
+    "licenseDeclared" : "NOASSERTION",
+    "name" : "Jena"
+  }, {
+    "SPDXID" : "SPDXRef-Saxon",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+    } ],
+    "copyrightText" : "Copyright Saxonica Ltd",
+    "description" : "The Saxon package is a collection of tools for processing XML documents.",
+    "downloadLocation" : "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download",
+    "filesAnalyzed" : false,
+    "homepage" : "http://saxon.sourceforge.net/",
+    "licenseComments" : "Other versions available for a commercial license",
+    "licenseConcluded" : "MPL-1.0",
+    "licenseDeclared" : "MPL-1.0",
+    "name" : "Saxon",
+    "packageFileName" : "saxonB-8.8.zip",
+    "versionInfo" : "8.8"
+  } ],
+  "files" : [ {
+    "SPDXID" : "SPDXRef-DoapSource",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+    } ],
+    "copyrightText" : "Copyright 2010, 2011 Source Auditor Inc.",
+    "fileContributors" : [ "Protecode Inc.", "SPDX Technical Team Members", "Open Logic Inc.", "Source Auditor Inc.", "Black Duck Software In.c" ],
+    "fileDependencies" : [ "SPDXRef-JenaLib", "SPDXRef-CommonsLangSrc" ],
+    "fileName" : "./src/org/spdx/parser/DOAPProject.java",
+    "fileTypes" : [ "SOURCE" ],
+    "licenseConcluded" : "Apache-2.0",
+    "licenseInfoInFiles" : [ "Apache-2.0" ]
+  }, {
+    "SPDXID" : "SPDXRef-CommonsLangSrc",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+    } ],
+    "comment" : "This file is used by Jena",
+    "copyrightText" : "Copyright 2001-2011 The Apache Software Foundation",
+    "fileContributors" : [ "Apache Software Foundation" ],
+    "fileName" : "./lib-source/commons-lang3-3.1-sources.jar",
+    "fileTypes" : [ "ARCHIVE" ],
+    "licenseConcluded" : "Apache-2.0",
+    "licenseInfoInFiles" : [ "Apache-2.0" ],
+    "noticeText" : "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\nThis product includes software developed by\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())"
+  }, {
+    "SPDXID" : "SPDXRef-JenaLib",
+    "checksums" : [ {
+      "algorithm" : "SHA1",
+      "checksumValue" : "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+    } ],
+    "comment" : "This file belongs to Jena",
+    "copyrightText" : "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
+    "fileContributors" : [ "Apache Software Foundation", "Hewlett Packard Inc." ],
+    "fileDependencies" : [ "SPDXRef-CommonsLangSrc" ],
+    "fileName" : "./lib-source/jena-2.6.3-sources.jar",
+    "fileTypes" : [ "ARCHIVE" ],
+    "licenseComments" : "This license is used by Jena",
+    "licenseConcluded" : "LicenseRef-1",
+    "licenseInfoInFiles" : [ "LicenseRef-1" ]
+  }, {
+    "SPDXID" : "SPDXRef-File",
+    "annotations" : [ {
+      "annotationDate" : "2011-01-29T18:30:22Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Person: File Commenter",
+      "comment" : "File level annotation"
+    } ],
+    "checksums" : [ {
+      "algorithm" : "MD5",
+      "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
+    }, {
+      "algorithm" : "SHA1",
+      "checksumValue" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
+    } ],
+    "comment" : "The concluded license was taken from the package level that the file was included in.\nThis information was found in the COPYING.txt file in the xyz directory.",
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "fileContributors" : [ "The Regents of the University of California", "Modified by Paul Mundt lethal@linux-sh.org", "IBM Corporation" ],
+    "fileName" : "./package/foo.c",
+    "fileTypes" : [ "SOURCE" ],
+    "licenseComments" : "The concluded license was taken from the package level that the file was included in.",
+    "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-2)",
+    "licenseInfoInFiles" : [ "GPL-2.0-only", "LicenseRef-2" ],
+    "noticeText" : "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the �Software�), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: \nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+  } ],
+  "snippets" : [ {
+    "SPDXID" : "SPDXRef-Snippet",
+    "comment" : "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.",
+    "copyrightText" : "Copyright 2008-2010 John Smith",
+    "licenseComments" : "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
+    "licenseConcluded" : "GPL-2.0-only",
+    "licenseInfoInSnippets" : [ "GPL-2.0-only" ],
+    "name" : "from linux kernel",
+    "ranges" : [ {
+      "endPointer" : {
+        "lineNumber" : 23,
+        "reference" : "SPDXRef-DoapSource"
+      },
+      "startPointer" : {
+        "lineNumber" : 5,
+        "reference" : "SPDXRef-DoapSource"
+      }
+    }, {
+      "endPointer" : {
+        "offset" : 420,
+        "reference" : "SPDXRef-DoapSource"
+      },
+      "startPointer" : {
+        "offset" : 310,
+        "reference" : "SPDXRef-DoapSource"
+      }
+    } ],
+    "snippetFromFile" : "SPDXRef-DoapSource"
+  } ],
+  "relationship" : [ {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-File",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement",
+    "relationshipType" : "COPY_OF"
+  }, {
+    "spdxElementId" : "SPDXRef-DOCUMENT",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "DESCRIBES"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-Saxon",
+    "relationshipType" : "DYNAMIC_LINK"
+  }, {
+    "spdxElementId" : "SPDXRef-Package",
+    "relatedSpdxElement" : "SPDXRef-JenaLib",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-CommonsLangSrc",
+    "relatedSpdxElement" : "NOASSERTION",
+    "relationshipType" : "GENERATED_FROM"
+  }, {
+    "spdxElementId" : "SPDXRef-JenaLib",
+    "relatedSpdxElement" : "SPDXRef-Package",
+    "relationshipType" : "CONTAINS"
+  }, {
+    "spdxElementId" : "SPDXRef-File",
+    "relatedSpdxElement" : "SPDXRef-fromDoap-0",
+    "relationshipType" : "GENERATED_FROM"
+  } ]
+}


### PR DESCRIPTION
Resolves issue #21 

The version of the JSON-LD context only includes singular versions of a property if there is a class that has a cardinality restriction of 0/1.


Signed-off-by: Gary O'Neall <gary@sourceauditor.com>