### PR TITLE
Add a unit test which duplicates issue#44

### DIFF
--- a/src/test/java/org/spdx/jacksonstore/MultiFormatStoreTest.java
+++ b/src/test/java/org/spdx/jacksonstore/MultiFormatStoreTest.java
@@ -531,6 +531,56 @@ public class MultiFormatStoreTest extends TestCase {
 	}
 	
 	/**			
+	 * Test documentDescribes and adding a DESCRIBES relationship with the same described element
+	 * causes issues when serializing and deserializing in the XML format
+	 * see issue #44 for context
+	 * @throws InvalidSPDXAnalysisException
+	 * @throws IOException 
+	 */
+	public void testDocumentDescribesXml() throws InvalidSPDXAnalysisException, IOException {
+		String documentUri = "https://someuri";
+        ModelCopyManager copyManager = new ModelCopyManager();
+        ISerializableModelStore modelStore = new MultiFormatStore(new InMemSpdxStore(), MultiFormatStore.Format.XML);
+        SpdxDocument document = SpdxModelFactory.createSpdxDocument(modelStore, documentUri, copyManager);
+        document.setSpecVersion(Version.TWO_POINT_THREE_VERSION);
+        document.setName("SPDX-tool-test");
+        Checksum sha1Checksum = Checksum.create(modelStore, documentUri, ChecksumAlgorithm.SHA1, "d6a770ba38583ed4bb4525bd96e50461655d2758");
+        AnyLicenseInfo concludedLicense = LicenseInfoFactory.parseSPDXLicenseString("LGPL-2.0-only OR LicenseRef-2");
+        SpdxFile fileA = document.createSpdxFile("SPDXRef-fileA", "./package/fileA.c", concludedLicense,
+                        Arrays.asList(new AnyLicenseInfo[0]), "Copyright 2008-2010 John Smith", sha1Checksum)
+                .build();
+        document.getDocumentDescribes().add(fileA);
+        assertEquals(1, document.getDocumentDescribes().size());
+        assertTrue(document.getDocumentDescribes().contains(fileA));
+        document.addRelationship(
+                document.createRelationship(
+                        fileA, RelationshipType.DESCRIBES, null
+                ));
+        assertTrue(document.verify().isEmpty());
+    	
+    	// test that it deserializes correctly
+    	Path tempDirPath = Files.createTempDirectory("mfsTest");
+    	File serFile = tempDirPath.resolve("testspdx.xml").toFile();
+    	assertTrue(serFile.createNewFile());
+    	try {
+    		try (OutputStream stream = new FileOutputStream(serFile)) {
+    			modelStore.serialize(documentUri, stream);
+    		}
+    		ISerializableModelStore resultStore = new MultiFormatStore(new InMemSpdxStore(), MultiFormatStore.Format.XML);
+    		try (InputStream inStream = new FileInputStream(serFile)) {
+    			assertEquals(documentUri, resultStore.deSerialize(inStream, false));
+    		}
+    		document = SpdxModelFactory.createSpdxDocument(resultStore, documentUri, copyManager);
+    		assertTrue(document.verify().isEmpty());
+    	} finally {
+    		if (serFile.exists()) {
+    			serFile.delete();
+    		}
+    		tempDirPath.toFile().delete();
+    	}
+	}
+	
+	/**			
 	 * Test if the hasFiles relationship produces more than one relationship
 	 * see issue #115 for context
 	 * @throws InvalidSPDXAnalysisException


### PR DESCRIPTION
This is a draft PR where we can add a solution to issue #44 once it has been developed.

The is likely related to [the code that removes duplicate relationships](https://github.com/spdx/spdx-java-jackson-store/blob/c19e3ea9db1534cede87c87ffbb07bdeedfc289a/src/main/java/org/spdx/jacksonstore/JacksonSerializer.java#L131).

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>