### PR TITLE
Update JSON and Jackson library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,27 +114,27 @@ This store supports serializing and deserializing files in JSON, YAML and XML fo
     <dependency>
     	<groupId>com.fasterxml.jackson.core</groupId>
     	<artifactId>jackson-databind</artifactId>
-    	<version>2.14.2</version>
+    	<version>2.15.0</version>
     </dependency>
     <dependency>
     	<groupId>com.fasterxml.jackson.dataformat</groupId>
     	<artifactId>jackson-dataformat-xml</artifactId>
-    	<version>2.14.2</version>
+    	<version>2.15.0</version>
     </dependency>
     <dependency>
     	<groupId>com.fasterxml.jackson.dataformat</groupId>
     	<artifactId>jackson-dataformat-yaml</artifactId>
-    	<version>2.14.2</version>
+    	<version>2.15.0</version>
     </dependency>
     <dependency>
     	<groupId>org.json</groupId>
     	<artifactId>json</artifactId>
-    	<version>20220924</version>
+    	<version>20230227</version>
     </dependency>
     <dependency>
     	<groupId>com.fasterxml.jackson.core</groupId>
     	<artifactId>jackson-core</artifactId>
-    	<version>2.14.2</version>
+    	<version>2.15.0</version>
     </dependency>
   </dependencies>
      <build>

--- a/pom.xml
+++ b/pom.xml
@@ -114,22 +114,22 @@ This store supports serializing and deserializing files in JSON, YAML and XML fo
     <dependency>
     	<groupId>com.fasterxml.jackson.core</groupId>
     	<artifactId>jackson-databind</artifactId>
-    	<version>2.14.0-rc1</version>
+    	<version>2.14.2</version>
     </dependency>
     <dependency>
     	<groupId>com.fasterxml.jackson.dataformat</groupId>
     	<artifactId>jackson-dataformat-xml</artifactId>
-    	<version>2.14.0-rc1</version>
+    	<version>2.14.2</version>
     </dependency>
     <dependency>
     	<groupId>com.fasterxml.jackson.dataformat</groupId>
     	<artifactId>jackson-dataformat-yaml</artifactId>
-    	<version>2.14.0-rc1</version>
+    	<version>2.14.2</version>
     </dependency>
     <dependency>
     	<groupId>org.json</groupId>
     	<artifactId>json</artifactId>
-    	<version>20190722</version>
+    	<version>20220924</version>
     </dependency>
     <dependency>
     	<groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@ This store supports serializing and deserializing files in JSON, YAML and XML fo
     <dependency>
     	<groupId>com.fasterxml.jackson.core</groupId>
     	<artifactId>jackson-core</artifactId>
-    	<version>2.14.0-rc1</version>
+    	<version>2.14.2</version>
     </dependency>
   </dependencies>
      <build>


### PR DESCRIPTION
this PR is in draft mode until there is a new release of the JSON library with https://github.com/stleary/JSON-java/pull/720 released.  This will resolve a stack overflow DOS vulnerability (CVE-2022-45688).

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>