### PR TITLE
Fix for CVE-2023-5072

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@ This store supports serializing and deserializing files in JSON, YAML and XML fo
     <dependency>
     	<groupId>org.json</groupId>
     	<artifactId>json</artifactId>
-    	<version>20230227</version>
+    	<version>20231013</version>
     </dependency>
     <dependency>
     	<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
The purpose of this change is to use a version of `org.json:json` that is not vulnerable to [CVE-2023-5072](https://nvd.nist.gov/vuln/detail/CVE-2023-5072).

cc: @goneall 