### PR TITLE
Fix JSON node sorting

### DIFF
--- a/src/main/java/org/spdx/jacksonstore/JacksonSerializer.java
+++ b/src/main/java/org/spdx/jacksonstore/JacksonSerializer.java
@@ -161,6 +161,11 @@ public class JacksonSerializer {
 			}
 			List<String> fieldNames = new ArrayList<>();
 			arg0.fieldNames().forEachRemaining(fieldNames::add);
+			arg1.fieldNames().forEachRemaining(field -> {
+				if (!fieldNames.contains(field)) {
+					fieldNames.add(field);
+				}
+			});
 			Collections.sort(fieldNames);
 			int retval = 0;
 			for (String fieldName:fieldNames) {
@@ -335,7 +340,7 @@ public class JacksonSerializer {
 	 * Sorts the elements of an ArrayNode in place
 	 * @param an ArrayNode to sort
 	 */
-	private void sortArrayNode(ArrayNode an) {
+	protected static void sortArrayNode(ArrayNode an) {
 		List<JsonNode> arrayElements = StreamSupport.stream(an.spliterator(), false).sorted(NODE_COMPARATOR).collect(Collectors.toList());
 		an.removeAll();
 		an.addAll(arrayElements);

--- a/testResources/unsortedrelationships.json
+++ b/testResources/unsortedrelationships.json
@@ -1,0 +1,7029 @@
+[ {
+  "spdxElementId" : "SPDXRef-DOCUMENT",
+  "relationshipType" : "DESCRIBES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--42921b290",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-917cd9f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-53828b1d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6a0841cb0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3bac825c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--690b8be40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-e3321990"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-44f012540"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-618778ca0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--30f7d460"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--44124f5a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-72650fb70",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6613c8e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7459bae70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5bf3173a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-297088e10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-1915ea1f0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3c48d8390"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6d7af5a80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--35d3040f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1d9f288c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--4fdcb27a0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-a13fa320"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--59e24d330",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7245baa30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--3a81804a0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--9b6660f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2fe910ef0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7bdaa5730"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--568bc5eb0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3a04a5c50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7b1d2c6a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2ffa72250"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "OPTIONAL_COMPONENT_OF",
+  "relatedSpdxElement" : "SPDXRef-20a519830",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--54584c240"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-543f84640"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6d4b85870"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5996ad730"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "OPTIONAL_COMPONENT_OF",
+  "relatedSpdxElement" : "SPDXRef-59ad13500",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--59a2fee80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7e81fe570"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4cd8b4350"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-31f2388a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "OPTIONAL_COMPONENT_OF",
+  "relatedSpdxElement" : "SPDXRef-626d2c820",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-11302cc30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1e969fc0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-13ddf12b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7cb076730"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "OPTIONAL_COMPONENT_OF",
+  "relatedSpdxElement" : "SPDXRef--588fa5780",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-43fc25f30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--667a5d260"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-293379860"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6c8a71050"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3878039f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2efe5dec0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--73c63cef0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-267cc63d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-126c94c30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--148e0dfa0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-100cab020"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--195e02ba0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3c78499b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6ebbae890"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--10a13f600"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-610b29c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--491ab4340"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1c3415940"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6efbc22c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4d7d57e10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-1bae4edb0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--a4f3e780"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--629feed20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4e3dca490"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-659f3d420"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--443a61970",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5fdf510d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-395020960"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3efd75b20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--51a7cd070"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2e685c8d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-716995690"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-582e92820"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6c7bc5900"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6aa7f6cc0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--20d3a42f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-142dc93c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7c9521980"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--5ebc3d150",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1d862a40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--51ad22810"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6fcdc1b90"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--46681db60"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-76a5db1b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3a86c0d20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--cd8e050"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--42aed33b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--23becf470"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7b7ebf430"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2e7675810"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7b0710390"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-777f702c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1a06d7700"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2599fc280"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--713e57950"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3f8139310"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5b5c59e70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7abee9780"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--78c14c6d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-23d20cbe0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--461366840"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-359f5a80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3d02c3440"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7354baaa0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3e399d620"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1b27a5950"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--59c30b210"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--27435e340"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6a3191540"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-729dba0f0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7ab7b34d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-462a54eb0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--65ec2f670"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-525677650"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-663f4ae50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7abe128f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "OPTIONAL_COMPONENT_OF",
+  "relatedSpdxElement" : "SPDXRef--7fe40c850",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-18bd99eb0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3fefab3a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4eef581d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6681ed0c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--56d2e850"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2329b3ab0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5d0095400"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "OPTIONAL_COMPONENT_OF",
+  "relatedSpdxElement" : "SPDXRef--1c1af79f0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--f17d3cc0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3dae82870"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--209f77020"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-41e284540"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7c61ec200"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1e769dc40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "OPTIONAL_COMPONENT_OF",
+  "relatedSpdxElement" : "SPDXRef--597c8f460",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--37656a2f0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-4e688a140",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--11c834e10",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-6b6eadc30",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-1caef3770",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-2817aed40",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--77efca930",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--155aa5be0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--4decc8980",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-20a2f4520",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-3122f48c0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--1575b8020",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-1cb749490",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--133e36ab0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-408690960",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--6cde2f460",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--27e121c40",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-2504561c0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-5c4bd1a20",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--66ebf14a0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--30c3056c0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-2298aae30",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--462494a60",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3fb4303c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-405b5f420"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--252a45580"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-2108c9400",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--d3e627b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--69788ab40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--485292da0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--363f72aa0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4897c76a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--268158a60"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--46e873110"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-cd059010"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--447f3ea60"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--28e9e5d30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2281d6540"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--72e230760"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--332eab660"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5b59d93a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7cf0c38a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-155faef70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1eacde140"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-54c470b40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1256ea320"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1270409f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4ade47d80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-66fe587e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7b6ec6100"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-56c1de5a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-662741ee0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-493e3d20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-62ebf19e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-39c120a10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2dea16f70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-65a83ea0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--450836ca0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-65aaed980",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7aa5a3bb0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-615c168c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2827bd4d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--46f448f80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-23227b410"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3cfd1db00"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4d3cd540"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4c05ed4c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5dc287a30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--629196740",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--49751fb80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5a1183ce0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-25239ea70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--7725e2f80",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5aa30c900"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-77797f710"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-42edf46b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7e666fb10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5c5c86900"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7e01876e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3dcf80590"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-40746240"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2964d0ba0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--6ea84c060",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--32b134610"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-75cb4e370"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7c6ccda70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-781fd89a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--342e22610"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--641cf15e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3b72fe510"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-51b15adb0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--719fd7ff0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-9b555330"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-798b08030"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-4e379fe60",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-79da747f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--4fa889800",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--154c31480"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3b80c8870"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-798b5a030",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-52cfa3ed0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--72987f9d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6d95eaee0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2233a3c70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6993cc820"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--525d39310"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-163650dd0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--506acf480",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--457f56c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--78e4113e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2a35d3d10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-505e9eca0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--21fa927a0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2a22fdc40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-526c11ea0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7c2bd33c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1a9c8d0d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2d8ed7760"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3505f58c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3eef4460"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3b9e22180"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--f9450080"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-16af5ced0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-257144c40",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6094c4900"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3d309e970"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7adcee320"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-61deab5c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1e06815b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-23f4d2360"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-d326b890",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-698c43dd0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--51f2943e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-276aaf3f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--75afc4300"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--464a9bc00",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6c118500"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-661689500"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-746d89290",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-647358d20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--5b6300200",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--5a3fbd7e0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-16d2a8b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4a361d50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-5ef014060",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--5f4ff7ee0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--162d7c360"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-54ce30d20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--40a6592a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--246973c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-27ad89da0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4a3e04690"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-13ee78340",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--112ea6410"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--1b0106a50",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--64a83cc90",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2b38f8cd0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3fc00b6a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4ee278470"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6e064e500"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--79b4d20d0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--7e362e60",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-7761277c0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1eb32bf70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-29a601e00"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-79fbff8b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--6d7f62860",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-11f997d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--f4c454c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--245f91cb0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1799c2720"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--150dc280",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--39b6216b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-77ceff6c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--628302410",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--3faa20c70",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-39e5eb1e0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5a6bc66c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--1c799a610",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3be25f6f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-95d9cba0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--530e51860",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5c33d4a20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-3b5f3dc20",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-627e779d0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--2bcba6dd0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--1a6d2d570",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-c53bf1c0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2b80fc520"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--23c7184a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-f03a4df0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7f7dcb220"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--73f202c50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7ed3f63d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--690226d60"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-108bfde00"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-32d257650"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--122e7afb0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--d6ad9dd0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5c08554b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-139ae670"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2302e0580"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-26fd76770"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--4745193a0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--500a5f670",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--177fe1920"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-12a857c70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6a4983ac0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1e92cc420"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-568ab8e90"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7619e5810"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-487449b00",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2f9e51270"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-40d57b370"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4adaec040"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--542270c90"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--8312d9c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-14c2db2a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--71840aa80",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--26980d360"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--9cd24e50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2f9043250"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--624cfab0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5d8dbc240"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3493edf0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-18dae8780"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2bacdc0a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2424f3160"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-263ec8d60"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7a2eaffc0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-e7be0f10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5438ccc50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6f06edd90"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-402820ae0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7543a6f50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-436bed830"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1b75e90c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4ebb4d370"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-86256be0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--13632d2d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-594106150"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--81f41560"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-27f755c90"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-63dc42310"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--46ca91b00"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--569522640"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--35486d740",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3d6ae0130"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1c28be930"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--265db98d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-66078aba0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7db4bfc40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--54979bcd0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5c0b84980"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-746d94580",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--731c07f50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-35a895b30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-323959ca0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-75db6e0d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7b86ba750"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1108f0030"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--d043c800"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--35fada8b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3a11cf290"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--18b6dd450"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--247de3d20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7e77ccdb0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2b5dc8f70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5d8c63fb0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3c39d7690"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--59b651cf0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-70b36cc80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5293e6860"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-390d02f80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6a7713560"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5eb0248b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6d7fa0210"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--46efbb080"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--51cba050"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--31e5cdc60",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--54a01960",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-46043a7e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-51a090920"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-140508870"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5c714d40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-265a05b90"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1e9ecb690"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2e87aab30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2814d90a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-27e7d5f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--233d21270"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4a8b895e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--41a0c34e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--630466df0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5af8b4e70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--65c832680"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-7c58ba00",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1bc10fad0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--227918600"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--62f584730"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-437734da0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--540fd0d60"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3db1504b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--7c881b110",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--58cbbfa70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7d72d23c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--45ea45080"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--6c7696f00",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2c55e4c70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--615ce90f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-95f75030"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--17d25bea0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1fc67a120"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6471f0360"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6793aadf0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-7319389a0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--b58c4d50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-126ff94f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--537bfb900"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-13fa88cb0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4cd60fe00"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6d069e230"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1ed6b82e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-441f3a20",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--50e675380"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5f81ee7b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3befeb5e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3f6e55a80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2b0caee80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-60cf9250"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--21fd39b20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-866f2aa0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-56d73cfd0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2d98c7c10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1c38d2c40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--19c2d3560"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5492a1b10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5fd0875a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--41bd1aac0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2ea346c70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4be6334c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-211a750f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4b2c80d70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3b0d38510"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1758f0f40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--47c23b520"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3fbd6d270"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--18d419c70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--7f73cf3e0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1e2688300"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--414c917d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--761eb4320"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--6d2cfd000",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-24dd853f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2d0ee5160"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--8b88e9a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4a00d8300"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--60c8de340"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2f802b600"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--139d66f50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--63b9c0fa0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3e4447490"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5f0225340"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-52902fc50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-15ee27930"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--301491130"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4ae2c92d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--70d808b80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4b8cd3330"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-59ae13a50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-78bdfb0f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-750b7b8b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1c238ffe0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2048e2f40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2c1b84240"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-302bd08e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-68e744e20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--68ae5340"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-12c000840"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6f8c8e210"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2b8cc54e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-aef44fe0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3138dd900"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--65d1bde20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6dc1c0e40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3603f56d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--631a1ea00"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--622b68dd0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3f590be90"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-673365cc0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--95a77410"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5481b15b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--67a616e50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2649a0670"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6fb83dc70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7c23238a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--198f630d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--36f9b1c40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--238b4ffd0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5fcc8360"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-75693a1d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--20bf23120"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-75b68fe80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2c0238e40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-486b4cc80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7fb276c10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3f414f500"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4474e1e30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-46d85e2b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--b27e2750"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4e3446eb0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--667aa8410"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--37d961ad0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-f7c4c280"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-21662cac0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-712a6d530"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--89202ac0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-695e05370"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-73af3afe0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1df0adc00"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-77a1d7360"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2a369dcf0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-329c20fb0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-d9de31d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-79b51b300"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-40dc46fa0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--55f774f70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2f59a5f00"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--102b66d70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--56adb5c20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-543be1960"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--722f78c00"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5a5174f10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1ad3c5f60"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-55e99cd70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--63e639e90"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7407bc0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--56626eb40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-23576cc20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--48202bf20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4f4217450"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2b0694280"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7e1fa2fe0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--26b4180b0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5b9e85470"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-604cc61d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1b1f7f00"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7d9b447a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-77fc064f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-352f1c750"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4c603bab0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--32b325210"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3b40e48a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--107a69790"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-738ab98d0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--554a41140"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6b90e2230"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-3367bbd20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-409424d40"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--6c18922f0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4efed8a30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-716c1c090"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6eedd6f20"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5cd2a2340"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2aed6f10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--279990280"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5d021a8c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1f13bd840"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-700cacb70"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2dbac6d50"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6131a71e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--4acdad990"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--6a8f76180",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--370ad39d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7b4f12a60"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-255e5a30",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-23632db80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2e381a420"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--65fec500"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--38d43d1f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2136f4920"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--78c751390"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4b3b32d60"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1b4221230"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--52aa7e230"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-718fe8840"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-77a2fc7a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--7ce87f750"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-6d296f580"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--41bfb3970"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--259bdd5b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--46b223ce0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--47fbba2b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1c1b03de0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-556d604e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1c60ac4b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--b5235c30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2f33edf60"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3dc1be470"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5c278f2d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-342498710"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3d9d62770"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-4cdf905c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-60df331e0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-535ef3100"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6f7388880"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-181558e80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--3d27221b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1adadd620"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-29f99c4d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-5e915ea90"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7ffe11d80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--462f311d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2ecfa9150"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-753d12ae0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-1fa2148f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1326d8180"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--26a333ee0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--10770e5d0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--744e29e00"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--34a98a820"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--245f18940"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--79ff26ca0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--d1cb7b80"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--2bdf74410"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--5f77331a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7ca6b7ea0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-223beba10"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1bd4017a0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-2d57f0120"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-34241c240"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-7dc4a2040"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--20514c9b0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--eca85e90"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-50e4a3c30"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef-38831a4f0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--6510be4c0"
+}, {
+  "spdxElementId" : "SPDXRef--4b3779bf0",
+  "relationshipType" : "CONTAINS",
+  "relatedSpdxElement" : "SPDXRef--1dbe0c7b0"
+}, {
+  "spdxElementId" : "SPDXRef--6d2cfd000",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--5edc9b100",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--6d2cfd000",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--489b7c040",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--31e5cdc60",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-64f300010",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-7c58ba00",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-507cce4b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-7c58ba00",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-8fcb9610",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-7c58ba00",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-75b202660",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-7c58ba00",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--ee7c3580",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--42921b290",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--121906820",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--42921b290",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--337b44b00",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--42921b290",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-704cf4df0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--42921b290",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-4cc7c1a30",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--121906820",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--270c571a0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-1915ea1f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-443aa4220",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-618778ca0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--6850d5f40",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-618778ca0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--46c0242c0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-618778ca0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-6706460",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-618778ca0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--6b3306ff0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-20a519830",
+  "relationshipType" : "OPTIONAL_COMPONENT_OF",
+  "relatedSpdxElement" : "SPDXRef-328315830",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-20a519830",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--16e2de3a0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5ebc3d150",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-66605d7b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5ebc3d150",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--495387150",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-66605d7b0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--398f015a0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--35486d740",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--9a522c50",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--35486d740",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--9b5bae90",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--500a5f670",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--6472ff020",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--500a5f670",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--4cad470b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4cad470b0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-682aa7f70",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4cad470b0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--1f3864d0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5a3fbd7e0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-72d550e00",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-3b5f3dc20",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-47df751f0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-3b5f3dc20",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--2d67ea650",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--2d67ea650",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--7d2c0e2e0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--2d67ea650",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--5978a8a60",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5978a8a60",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--613f04890",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5978a8a60",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--63cf484e0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5978a8a60",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--5b380d7e0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--63cf484e0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-7fac75f60",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--63cf484e0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--eea434d0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-7fac75f60",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-461304b90",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--37656a2f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--1a519100",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--37656a2f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-1677c8730",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--37656a2f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-2a8be6810",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--37656a2f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-4af04ea80",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--37656a2f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-3f6cd7c30",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--37656a2f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-40f99590",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--37656a2f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--67b957640",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--37656a2f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-6964226d0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--1a519100",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-8de9c770",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-6964226d0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--625075270",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--155aa5be0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-1f4e1de30",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-1f4e1de30",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-76ac97880",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--133e36ab0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-c92d4910",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-1cb749490",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-3793089f0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-1cb749490",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-6c1e518e0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-3793089f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--37af3e070",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--462494a60",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--3b8386330",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--3b8386330",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--7e3c55880",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--3b8386330",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-4fc5b3f20",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--7e3c55880",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--515c0c510",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--7e3c55880",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--6cf832530",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--7e3c55880",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--117169100",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--6cf832530",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--72a31bba0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-4fc5b3f20",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-75ac8d9d0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-4fc5b3f20",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--2f8df5690",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--245f91cb0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-533f1dd20",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--245f91cb0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--7d4a69bf0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--245f91cb0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-11c6ec250",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--245f91cb0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--7d9e58350",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--245f91cb0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--4b2544eb0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--245f91cb0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-24e0d1c00",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--245f91cb0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-14ea2b160",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--245f91cb0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--26d9d4080",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-24e0d1c00",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-68f9a6950",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-24e0d1c00",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-369ccde10",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-24e0d1c00",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--3368cdcf0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-24e0d1c00",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-3dcd84770",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-3dcd84770",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-6d760d350",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-64d2707f0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-11ebbd760",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-6cc1360a0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-3abde4650",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-1866a8420",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-10ab2cbe0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-2f3ca7d00",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--41d2e1e00",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-5b62272b0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-42829f080",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--5bc667240",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-5ec1eae70",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-5726f48a0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-1e04d2da0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-108d0d4c0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-3c3b94990",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-68f9a6950",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--4113dc360",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-5ec1eae70",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-353b61100",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-353b61100",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-4363d8780",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-1866a8420",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-2e2966220",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-2f3ca7d00",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-64464d410",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--5bc667240",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--26eab64f0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-14ea2b160",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--19beb9f70",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--26d9d4080",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--28b74880",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6cde2f460",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--15aa67380",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-2504561c0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--5e9560570",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-2504561c0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-663c85680",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--5e9560570",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--5c814e5a0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--5e9560570",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--215f7ad80",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--5e9560570",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-5e1f6c250",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--215f7ad80",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-46f4400e0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--215f7ad80",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--2277e1030",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--2277e1030",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--4fa95e910",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4fa95e910",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--54d5e2b80",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-663c85680",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--54fcf2660",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--719fd7ff0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--4831b1a30",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--719fd7ff0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-3606acd70",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--628302410",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-60dab2ee0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--1b0106a50",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-7e75989f0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--1b0106a50",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--761e4a590",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-746d89290",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--578b6ea10",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-746d89290",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--1d451c860",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--2bcba6dd0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-312fd1d00",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--2bcba6dd0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--6ef5c9a80",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--6ef5c9a80",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--15bf64310",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--6ef5c9a80",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-e555e840",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--1c799a610",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-6b6e79830",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-2817aed40",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-522567f0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-2817aed40",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-1a08ac610",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-1a08ac610",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-1626cd630",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-1a08ac610",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-5307426a0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-1a08ac610",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-545c588f0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-1a08ac610",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--7350fb270",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-545c588f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-21e8feb30",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-522567f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--33c01b2b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4decc8980",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--ded22520",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-20a2f4520",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--61821ff10",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--6c18922f0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--4f5f15e30",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--629196740",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-32bb5010",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--7725e2f80",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--46a084840",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--7725e2f80",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-3669a8d60",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--7725e2f80",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-139cc2a50",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--7725e2f80",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-30be5c490",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--7725e2f80",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-514364600",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--7725e2f80",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-4364f3540",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--7725e2f80",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-55686f200",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--7725e2f80",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-92a2eb20",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--7725e2f80",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--3d2db2ba0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-30be5c490",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-52e147460",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-92a2eb20",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--6283b6ed0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-92a2eb20",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-1bdc03570",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-55686f200",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-494d611d0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-55686f200",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-3401be290",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-3669a8d60",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--843a2040",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4fa889800",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-12318cc00",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--150dc280",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--549b13b00",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5b6300200",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--1f41f29c0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5b6300200",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--abbcda90",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5b6300200",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--4225933a0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5b6300200",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--48004c0b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5b6300200",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-1425d24b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-1425d24b0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--209c91880",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--4225933a0",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--1a601f590",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--abbcda90",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-4bad529b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--530e51860",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--f81997b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-6b6eadc30",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-110845520",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-1caef3770",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--68edbf970",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-1caef3770",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--36505bc0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-1caef3770",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-290895df0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-1caef3770",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--549033790",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-1caef3770",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--50c236580",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-1caef3770",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--52f7f0010",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-1caef3770",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--11e61c170",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-1caef3770",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--67ac5cca0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-1caef3770",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--4fd49340",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--68edbf970",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-3f9ba98b0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--68edbf970",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-11ab55c20",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--68edbf970",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--728e20ad0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--68edbf970",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-67b8be0a0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--68edbf970",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--35c8104a0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--68edbf970",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--2f210ec20",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--68edbf970",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-698628fe0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--68edbf970",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--64726de40",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-698628fe0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-7cf1b4980",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-698628fe0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--13ab96610",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--67ac5cca0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-61be07650",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--50c236580",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-5a88c2b50",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-290895df0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-339468870",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-339468870",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-1876bd370",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-2108c9400",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-20534d740",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-2108c9400",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-d5a9bbf0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-2108c9400",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-5e13f06b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-2108c9400",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef-9805b7b0",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-20534d740",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--5e3e8be20",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef--5e3e8be20",
+  "relationshipType" : "DYNAMIC_LINK",
+  "relatedSpdxElement" : "SPDXRef--3e8c3270",
+  "comment" : "Relationship based on Maven POM file dependency information"
+}, {
+  "spdxElementId" : "SPDXRef-798b5a030",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--21d5e5020",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-798b5a030",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--4b7ce8760",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-798b5a030",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--d3fd5630",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-798b5a030",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-333c611a0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-798b5a030",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-3065907f0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-798b5a030",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--6d53d08d0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6d53d08d0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-6dcca4a60",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6d53d08d0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-6799bb400",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6d53d08d0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-7bd32a470",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6d53d08d0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-35bfc2010",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-6dcca4a60",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--66fc899b0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-6dcca4a60",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-6a049c6e0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-7bd32a470",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--1c0af6520",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-7bd32a470",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--5680de2c0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--1c0af6520",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--54b2e9040",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--54b2e9040",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--657f91160",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--54b2e9040",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--1ae827380",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--54b2e9040",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-2c347ebc0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--54b2e9040",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--58c1db800",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--54b2e9040",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--689ce9cf0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--54b2e9040",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--2b4acc9b0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--2b4acc9b0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--1f50e85b0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-333c611a0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-4d99bf770",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-333c611a0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-4935f00",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-333c611a0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-15802ccd0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-4d99bf770",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-6c8ed1340",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-3065907f0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-26c76c0f0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-3065907f0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--9b5fa410",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-26c76c0f0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-3f3f20070",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-26c76c0f0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--784b39d60",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-3f3f20070",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-2eccf2770",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--9b5fa410",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-82a2f7b0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--9b5fa410",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-173051d00",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-173051d00",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--5281c8a70",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--d3fd5630",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--1c5610e60",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--d3fd5630",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-5328fa60",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--1c5610e60",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-5bdd9f610",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--1c5610e60",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--4ec74ff30",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6a8f76180",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-1f03ccdf0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6a8f76180",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--4e5e4c4a0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6a8f76180",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--3c175a6e0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--3c175a6e0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-5115fbee0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-1f03ccdf0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-57e982c50",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-65aaed980",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-2da022090",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-65aaed980",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--4b4011b30",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-65aaed980",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--359213a30",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-65aaed980",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--16f381b00",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--4b4011b30",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--65900fe50",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-d326b890",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-1442586f0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-d326b890",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--306b31eb0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-d326b890",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--7e230b2e0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-d326b890",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-1c801d800",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--7e230b2e0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-7f2f95d90",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--7e230b2e0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--132f99ce0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--306b31eb0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--5dd99fa00",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6d7f62860",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-4530067d0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6d7f62860",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--6bc411b50",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6d7f62860",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--779c83c10",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6d7f62860",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--1be9c1e30",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6d7f62860",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-2eea9a6a0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--6d7f62860",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--360ae3860",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--1be9c1e30",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-ae0a61f0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-ae0a61f0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-22b401af0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-ae0a61f0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--38bae86c0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--38bae86c0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-585c9680",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-585c9680",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--4c8c3f160",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-22b401af0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-34248bf50",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-22b401af0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--452d2b300",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--54a01960",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-4021c6380",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--54a01960",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--1d93146a0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--1d93146a0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-7371e7360",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-7371e7360",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--41171f380",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-7371e7360",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-6976dea70",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-7371e7360",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-657cdcb40",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef-6976dea70",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef-14be30cb0",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--26b4180b0",
+  "relationshipType" : "TEST_DEPENDENCY_OF",
+  "relatedSpdxElement" : "SPDXRef--421760710",
+  "comment" : "Relationship created based on Maven POM information"
+}, {
+  "spdxElementId" : "SPDXRef--2d8ed7760",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--744e29e00",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-661689500",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5dc287a30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5492a1b10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3493edf0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6f8c8e210",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1c1b03de0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2302e0580",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--8b88e9a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2b8cc54e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-14c2db2a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7d9b447a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--51f2943e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4474e1e30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1eacde140",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--78e4113e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-79fbff8b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--414c917d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-263ec8d60",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-51b15adb0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--18b6dd450",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--62f584730",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3c48d8390",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1a9c8d0d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1eb32bf70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2aed6f10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7e77ccdb0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-750b7b8b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-f03a4df0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-79b51b300",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--19c2d3560",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--462f311d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-35a895b30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-402820ae0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7d72d23c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--491ab4340",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4e3446eb0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--30f7d460",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--81f41560",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2f9043250",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-753d12ae0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7ab7b34d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--177fe1920",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-11302cc30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-95d9cba0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-77a2fc7a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7db4bfc40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--32b134610",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5cd2a2340",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-698c43dd0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-493e3d20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-15ee27930",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--265db98d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7fb276c10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-662741ee0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6f7388880",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6d7af5a80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6c8a71050",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2424f3160",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-73af3afe0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1df0adc00",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7f7dcb220",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3505f58c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2329b3ab0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-25239ea70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7ce87f750",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6c118500",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6a3191540",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6eedd6f20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2233a3c70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4d7d57e10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2a35d3d10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--46f448f80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4e3dca490",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-52cfa3ed0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--52aa7e230",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4efed8a30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--cd8e050",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-46d85e2b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3e4447490",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-75693a1d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-556d604e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-d9de31d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--60c8de340",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-21662cac0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--301491130",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-f7c4c280",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4d3cd540",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3a11cf290",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-712a6d530",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-aef44fe0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-866f2aa0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--67a616e50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-26fd76770",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--72987f9d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3b9e22180",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--46e873110",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5f0225340",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5293e6860",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--450836ca0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6a0841cb0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-781fd89a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--56d2e850",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-e7be0f10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--b58c4d50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3dc1be470",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-68e744e20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--540fd0d60",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--227918600",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3f6e55a80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7459bae70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3b72fe510",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7407bc0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2048e2f40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4cd60fe00",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--d1cb7b80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3a86c0d20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--a4f3e780",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4be6334c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2ffa72250",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-342498710",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-18dae8780",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--26980d360",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--17d25bea0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--59b651cf0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3bac825c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3fb4303c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1a06d7700",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--54584c240",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--49751fb80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-12c000840",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2ecfa9150",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7bdaa5730",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--63e639e90",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2c1b84240",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--525d39310",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--34a98a820",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3fefab3a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--233d21270",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-462a54eb0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1e92cc420",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6c7bc5900",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--554a41140",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-38831a4f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--252a45580",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-66fe587e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2a369dcf0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5d8dbc240",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--56adb5c20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-297088e10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--20d3a42f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6efbc22c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--342e22610",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-60df331e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2bacdc0a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-78bdfb0f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-11f997d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2f33edf60",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-323959ca0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--50e675380",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3367bbd20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-34241c240",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--246973c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7e81fe570",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--eca85e90",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--70d808b80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--75afc4300",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-51a090920",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-293379860",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--641cf15e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--112ea6410",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1d862a40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-27f755c90",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6aa7f6cc0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--65fec500",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-223beba10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--21fd39b20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-695e05370",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7b6ec6100",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2fe910ef0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5a6bc66c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-16af5ced0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7aa5a3bb0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3db1504b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6a7713560",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-e3321990",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-23576cc20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7adcee320",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6793aadf0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2ea346c70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--45ea45080",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5a5174f10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2f9e51270",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--95a77410",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-cd059010",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2c0238e40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--38d43d1f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-31f2388a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6a4983ac0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3cfd1db00",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-41e284540",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7ed3f63d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-75b68fe80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1ad3c5f60",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--48202bf20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5a1183ce0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1108f0030",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6d95eaee0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1b1f7f00",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2efe5dec0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-23632db80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--27435e340",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-32d257650",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5b5c59e70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2a22fdc40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4a361d50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-75cb4e370",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--542270c90",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5b9e85470",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-77fc064f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-23f4d2360",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--39b6216b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-140508870",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4ade47d80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6e064e500",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--26a333ee0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4a8b895e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--78c751390",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--731c07f50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-211a750f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4a00d8300",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1c60ac4b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--20514c9b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3603f56d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-716c1c090",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7abe128f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--51ad22810",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-44f012540",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2c55e4c70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1e06815b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--65c832680",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6094c4900",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7e1fa2fe0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-13ddf12b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4c05ed4c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-139ae670",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-329c20fb0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3c78499b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-86256be0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--363f72aa0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--f9450080",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-659f3d420",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4eef581d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4adaec040",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-23d20cbe0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5af8b4e70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--47fbba2b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5f81ee7b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7b86ba750",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-29f99c4d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--667a5d260",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2b0694280",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--139d66f50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-23227b410",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--722f78c00",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3f590be90",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1c238ffe0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5b59d93a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--10a13f600",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3f8139310",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2b0caee80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--245f18940",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1f13bd840",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-405b5f420",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-12a857c70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--35d3040f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1adadd620",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1326d8180",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--23c7184a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1bc10fad0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6131a71e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-437734da0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6dc1c0e40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3fc00b6a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5d021a8c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1d9f288c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7b4f12a60",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6613c8e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-390d02f80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-77a1d7360",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5d0095400",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2964d0ba0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-543f84640",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7b0710390",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2d98c7c10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--41a0c34e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-673365cc0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-352f1c750",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3d9d62770",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5c0b84980",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--47c23b520",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4c603bab0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7c2bd33c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2827bd4d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6510be4c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--568bc5eb0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-265a05b90",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7c6ccda70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1fc67a120",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--332eab660",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--154c31480",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-526c11ea0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--51cba050",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5438ccc50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-267cc63d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-50e4a3c30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1dbe0c7b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-56d73cfd0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--569522640",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--89202ac0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5bf3173a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-436bed830",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3efd75b20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1fa2148f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--d043c800",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--d6ad9dd0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--36f9b1c40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-40dc46fa0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--73f202c50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4b8cd3330",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--56626eb40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1b75e90c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3fbd6d270",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-917cd9f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6d7fa0210",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7543a6f50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6471f0360",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-276aaf3f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--37d961ad0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2d57f0120",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1e769dc40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--55f774f70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5c5c86900",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--10770e5d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--23becf470",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-56c1de5a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-543be1960",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6b90e2230",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2bdf74410",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--457f56c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3138dd900",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7245baa30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4ee278470",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--268158a60",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--32b325210",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--148e0dfa0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-718fe8840",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7619e5810",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--630466df0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-55e99cd70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3be25f6f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-302bd08e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2e381a420",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3dcf80590",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--f4c454c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--713e57950",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1b4221230",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-43fc25f30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7e666fb10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-486b4cc80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5c08554b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--690b8be40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-126c94c30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5d8c63fb0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-700cacb70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4cd8b4350",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4cdf905c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5c33d4a20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--102b66d70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-70b36cc80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-604cc61d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7354baaa0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-53828b1d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-77ceff6c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--58cbbfa70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-594106150",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--107a69790",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-409424d40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--79ff26ca0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--162d7c360",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2dea16f70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--461366840",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-40746240",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5f77331a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2b38f8cd0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-777f702c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-525677650",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5481b15b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6993cc820",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5fcc8360",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-9b555330",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4acdad990",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-663f4ae50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-647358d20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4ae2c92d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5c714d40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--690226d60",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--20bf23120",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2e87aab30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--13632d2d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--46ca91b00",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--65ec2f670",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2d0ee5160",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--44124f5a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2649a0670",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4897c76a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--46b223ce0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1758f0f40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-505e9eca0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1b27a5950",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--46681db60",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--68ae5340",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5e915ea90",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6d296f580",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1e969fc0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4ebb4d370",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--9cd24e50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--40a6592a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2e7675810",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7dc4a2040",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3d6ae0130",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--667aa8410",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-13fa88cb0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7ffe11d80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--d3e627b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-108bfde00",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7cb076730",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-61deab5c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2b5dc8f70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1c38d2c40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-568ab8e90",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-54c470b40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3878039f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5aa30c900",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--629feed20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-610b29c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7cf0c38a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3dae82870",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-54ce30d20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-24dd853f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--9b6660f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-60cf9250",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--41bd1aac0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5fdf510d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7e01876e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-63dc42310",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1c28be930",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--370ad39d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--59c30b210",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2599fc280",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--279990280",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2b80fc520",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--631a1ea00",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1270409f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3e399d620",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-615c168c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1e2688300",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-42edf46b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-126ff94f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-40d57b370",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6d4b85870",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-535ef3100",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3d02c3440",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--5c278f2d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-79da747f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-46043a7e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4a3e04690",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7a2eaffc0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7b7ebf430",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3a04a5c50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-395020960",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-95f75030",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4b2c80d70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7b1d2c6a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5eb0248b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-a13fa320",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--238b4ffd0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--537bfb900",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5996ad730",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-29a601e00",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--f17d3cc0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--46efbb080",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-75db6e0d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2814d90a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6681ed0c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--63b9c0fa0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3befeb5e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2dbac6d50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--28e9e5d30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2e685c8d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-155faef70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--51a7cd070",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--78c14c6d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2136f4920",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-716995690",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1799c2720",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--615ce90f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--42aed33b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--54979bcd0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2281d6540",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1bd4017a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3d27221b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-52902fc50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3b40e48a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--8312d9c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3d309e970",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6d069e230",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--35fada8b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-3b0d38510",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-62ebf19e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-100cab020",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--18d419c70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--622b68dd0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-39c120a10",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--447f3ea60",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3b80c8870",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--59a2fee80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--65d1bde20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-27e7d5f0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--1e9ecb690",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7c23238a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1256ea320",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6fb83dc70",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7c9521980",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--72e230760",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--259bdd5b0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-77797f710",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-798b08030",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-5fd0875a0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-181558e80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--209f77020",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--247de3d20",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--4f4217450",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6fcdc1b90",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7abee9780",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3eef4460",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-4b3b32d60",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--69788ab40",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3c39d7690",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-59ae13a50",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-7ca6b7ea0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-65a83ea0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-142dc93c0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1ed6b82e0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--7c61ec200",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-1c3415940",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--2f802b600",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-163650dd0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--b5235c30",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-2f59a5f00",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--6ebbae890",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-582e92820",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--b27e2750",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-18bd99eb0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--41bfb3970",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-6f06edd90",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--3f414f500",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--761eb4320",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-66078aba0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef-359f5a80",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+}, {
+  "spdxElementId" : "SPDXRef--198f630d0",
+  "relationshipType" : "GENERATES",
+  "relatedSpdxElement" : "SPDXRef--4b3779bf0",
+  "comment" : ""
+} ]


### PR DESCRIPTION
Fixes an issue where we may compare two JSON objects and get different results based on which direction the compare is made.  This was caused by having a different list of properties for the compare if the two JSON nodes had different lists of properties.