### PR TITLE
Add Javadoc links to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,18 @@
 Contributing
 ============
+
 Thank you for your interest in `spdx-java-jackson-store`. The project is open-source software, and bug reports, suggestions, and most especially patches are welcome.
 
 Issues
 ------
+
 `spdx-java-jackson-store` has a [project page on GitHub](https://github.com/spdx/spdx-java-jdf-store) where you can [create an issue](https://github.com/spdx/spdx-java-jackson-store/issues) to report a bug, make a suggestion, or propose a substantial change or improvement that you might like to make. You may also wish to contact the SPDX working group technical team through its mailing list, [spdx-tech@lists.spdx.org](mailto:spdx-tech@lists.spdx.org).
 
 If you would like to work on a fix for any issue, please assign the issue to yourself prior to creating a Pull Request.
 
 Pull Requests
 -------
+
 The source code for `spdx-java-jackson-store` is hosted on [github.com/spdx/spdx-java-jackson-store](https://github.com/spdx/spdx-java-jackson-store). Please review [open pull requests](https://github.com/spdx/spdx-java-jackson-store/pulls) and [active branches](https://github.com/spdx/spdx-java-jackson-store/branches) before committing time to a substantial revision. Work along similar lines may already be in progress.
 
 To submit a pull request via GitHub, fork the repository, create a topic branch from `master` for your work, and send a pull request when ready. If you would prefer to send a patch or grant access to pull from your own Git repository, please contact the project's contributors by e-mail.
@@ -20,4 +23,5 @@ Once implemented, submit a pull request with `spec/X.X` branch as the parent bra
 
 Licensing
 ---------
+
 However you choose to contribute, please sign-off in each of your commits that you license your contributions under the terms of [the Developer Certificate of Origin](https://developercertificate.org/). Git has utilities for signing off on commits: `git commit -s` signs a current commit, and `git rebase --signoff <revision-range>` retroactively signs a range of past commits.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # spdx-java-jackson-store
+
+[![javadoc](https://javadoc.io/badge2/org.spdx/spdx-jackson-store/javadoc.svg)](https://javadoc.io/doc/org.spdx/spdx-jackson-store)
+
 Storage for SPDX documents utilizing [Jackson Databind](https://github.com/FasterXML/jackson-databind).
 
 This store supports serializing and deserializing files in JSON, YAML and XML formats.
 
 This library utilizes the [SPDX Java Library Storage Interface](https://github.com/spdx/Spdx-Java-Library#storage-interface) extending the `ExtendedSpdxStore` which allows for utilizing any underlying store which implements the [SPDX Java Library Storage Interface](https://github.com/spdx/Spdx-Java-Library#storage-interface).
 
-# Code quality badges
+## Code quality badges
 
-|   [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=spdx-jackson-store&metric=bugs)](https://sonarcloud.io/dashboard?id=spdx-jackson-store)    | [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-jackson-store&metric=security_rating)](https://sonarcloud.io/dashboard?id=spdx-jackson-store) | [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-jackson-store&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=spdx-jackson-store) | [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=spdx-jackson-store&metric=sqale_index)](https://sonarcloud.io/dashboard?id=spdx-jackson-store) |
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=spdx-jackson-store&metric=bugs)](https://sonarcloud.io/dashboard?id=spdx-jackson-store)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-jackson-store&metric=security_rating)](https://sonarcloud.io/dashboard?id=spdx-jackson-store)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-jackson-store&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=spdx-jackson-store)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=spdx-jackson-store&metric=sqale_index)](https://sonarcloud.io/dashboard?id=spdx-jackson-store)
 
-# Using the Library
+## Using the Library
 
 This library is intended to be used in conjunction with the [SPDX Java Library](https://github.com/spdx/Spdx-Java-Library).
 
@@ -22,10 +28,15 @@ Create an instance of `MultiFormatStore(IModelStore baseStore, Format format)` p
 - `XML` - XML Format
 - `YAML` - YAML format
 
-# Serializing and Deserializing
+## Serializing and Deserializing
 
 This library supports the `ISerializableModelStore` interface for serializing and deserializing files based on the format specified.
 
-# Development Status
+## API Documentation
+
+- [Released API documentation](https://www.javadoc.io/doc/org.spdx/spdx-jackson-store) (as released on Maven Central)
+- [Development API documentation](https://spdx.github.io/spdx-java-jackson-store/) (updated with each GitHub change)
+
+## Development Status
 
 Mostly stable - although it has not been widely used.


### PR DESCRIPTION
Add links to Javadoc on javadoc.io and GitHub Pages