### PR TITLE
Handle pre-3.0 specVersions in MultiFormatStore serialize guard.

### DIFF
--- a/src/main/java/org/spdx/jacksonstore/MultiFormatStore.java
+++ b/src/main/java/org/spdx/jacksonstore/MultiFormatStore.java
@@ -181,7 +181,7 @@ public class MultiFormatStore extends ExtendedSpdxStore implements ISerializable
 		JacksonSerializer serializer = new JacksonSerializer(outputMapper, format, verbose, this);
 		JsonNode output;
 		if (Objects.nonNull(modelObject)) {
-			if (modelObject.getSpecVersion().compareTo("3.0") >= 0) {
+			if (!modelObject.getSpecVersion().startsWith("SPDX-") && modelObject.getSpecVersion().compareTo("3.0") >= 0) {
 				logger.error("Attempting to serialize an SPDX Spec version 3 model object");
 				throw new InvalidSPDXAnalysisException("Attempting to serialize an SPDX Spec version 3 model object");
 			}

--- a/src/test/java/org/spdx/jacksonstore/MultiFormatStoreTest.java
+++ b/src/test/java/org/spdx/jacksonstore/MultiFormatStoreTest.java
@@ -761,6 +761,25 @@ public class MultiFormatStoreTest extends TestCase {
 		}
 	}
 
+	/**
+	 * Regression test for the spec-version guard in serialize(OutputStream, CoreModelObject).
+	 * "SPDX-2.3".compareTo("3.0") &gt; 0 (lexicographic), so the &gt;= 0 guard incorrectly fires
+	 * for all SPDX 2.x documents when a modelObject is supplied.
+	 */
+	public void testSerializeWithModelObjectSpdxV2() throws InvalidSPDXAnalysisException, IOException {
+		File jsonFile = new File(JSON_FILE_PATH); // SPDX 2.3 fixture, with "SPDX-2.3" specVersion
+		MultiFormatStore store = new MultiFormatStore(new InMemSpdxStore(), Format.JSON_PRETTY);
+		try (InputStream input = new FileInputStream(jsonFile)) {
+			store.deSerialize(input, false);
+		}
+		String documentUri = store.getDocumentUris().toArray(new String[0])[0];
+		SpdxDocument doc = new SpdxDocument(store, documentUri, null, false);
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		store.serialize(out, doc);
+		assertTrue("Serialized output should not be empty", out.size() > 0);
+	}
+
 	public void testRegressionSort() throws IOException {
 		File jsonFile = new File(UNSORTED_RELATIONSHIPS);
 		ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);


### PR DESCRIPTION
In https://github.com/spdx/spdx-java-jackson-store/commit/42f69e2 a guard was added against the `specVersion` while serializing. It checks ">= '3.0'", but before 3.0 specVersion values looked like "SPDX-2.3" (correct me if I'm wrong). This adds a regression test and fix for the older versions.

This fixes a failure we ran into after upgrading to 2.0.5 of the library:

```
abc.def.TransformationException: Unable to serialize SPDX JSON for https://abc.def/spdx/some-project
      at app//abc.def.Spdx23SbomGenerator.serializeSbom(Spdx23SbomGenerator.java:87)

      Caused by:
      org.spdx.core.InvalidSPDXAnalysisException: Attempting to serialize an SPDX Spec version 3 model object
          at app//org.spdx.jacksonstore.MultiFormatStore.serialize(MultiFormatStore.java:186)
          at app//abc.def.Spdx23SbomGenerator.serializeSbom(Spdx23SbomGenerator.java:83)
          ... 2 more
```